### PR TITLE
adding managedclusteraddons/finalizers to clusterrole

### DIFF
--- a/charts/managed-serviceaccount/templates/clusterrole.yaml
+++ b/charts/managed-serviceaccount/templates/clusterrole.yaml
@@ -18,6 +18,7 @@ rules:
       - managedclusteraddons
       - clustermanagementaddons/status
       - managedclusteraddons/status
+      - managedclusteraddons/finalizers
     verbs:
       - get
       - list


### PR DESCRIPTION
Signed-off-by: Nathan Weatherly <nweather@redhat.com>

When using `managed-serviceaccount`, I saw the following error in the logs of the `managed-serviceaccount-addon-manager` pod.

<details>
  <summary>Logs</summary>

```
E0118 17:37:43.837870       1 base_controller.go:270] "addon-registration-controller" controller failed to sync "nweather-managed/managed-serviceaccount", err: roles.rbac.authorization.k8s.io "managed-serviceaccount-addon-agent" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
E0118 17:37:58.643014       1 base_controller.go:270] "cluster-management-addon-controller" controller failed to sync "local-cluster/managed-serviceaccount", err: managedclusteraddons.addon.open-cluster-management.io "managed-serviceaccount" is forbidden: cannot set an ownerRef on a resource you can't delete: , <nil>
I0118 17:37:59.168976       1 event.go:282] Event(v1.ObjectReference{Kind:"Namespace", Namespace:"open-cluster-management-addon", Name:"open-cluster-management-addon", UID:"", APIVersion:"v1", ResourceVersion:"", FieldPath:""}): type: 'Warning' reason: 'ManifestWorkCreateFailed' Failed to create ManifestWork local-cluster/addon-managed-serviceaccount-deploy: manifestworks.work.open-cluster-management.io "addon-managed-serviceaccount-deploy" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
E0118 17:37:59.176724       1 base_controller.go:270] "addon-deploy-controller" controller failed to sync "local-cluster/managed-serviceaccount", err: manifestworks.work.open-cluster-management.io "addon-managed-serviceaccount-deploy" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
E0118 17:38:00.728698       1 base_controller.go:270] "addon-registration-controller" controller failed to sync "local-cluster/managed-serviceaccount", err: roles.rbac.authorization.k8s.io "managed-serviceaccount-addon-agent" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
E0118 17:38:37.050479       1 base_controller.go:270] "cluster-management-addon-controller" controller failed to sync "nweather-managed/managed-serviceaccount", err: managedclusteraddons.addon.open-cluster-management.io "managed-serviceaccount" is forbidden: cannot set an ownerRef on a resource you can't delete: , <nil>
I0118 17:38:37.758950       1 event.go:282] Event(v1.ObjectReference{Kind:"Namespace", Namespace:"open-cluster-management-addon", Name:"open-cluster-management-addon", UID:"", APIVersion:"v1", ResourceVersion:"", FieldPath:""}): type: 'Warning' reason: 'ManifestWorkCreateFailed' Failed to create ManifestWork nweather-managed/addon-managed-serviceaccount-deploy: manifestworks.work.open-cluster-management.io "addon-managed-serviceaccount-deploy" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
E0118 17:38:37.765500       1 base_controller.go:270] "addon-deploy-controller" controller failed to sync "nweather-managed/managed-serviceaccount", err: manifestworks.work.open-cluster-management.io "addon-managed-serviceaccount-deploy" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
E0118 17:38:39.234989       1 base_controller.go:270] "addon-registration-controller" controller failed to sync "nweather-managed/managed-serviceaccount", err: roles.rbac.authorization.k8s.io "managed-serviceaccount-addon-agent" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
E0118 17:47:43.654335       1 base_controller.go:270] "cluster-management-addon-controller" controller failed to sync "local-cluster/managed-serviceaccount", err: managedclusteraddons.addon.open-cluster-management.io "managed-serviceaccount" is forbidden: cannot set an ownerRef on a resource you can't delete: , <nil>
E0118 17:47:43.664311       1 base_controller.go:270] "cluster-management-addon-controller" controller failed to sync "nweather-managed/managed-serviceaccount", err: managedclusteraddons.addon.open-cluster-management.io "managed-serviceaccount" is forbidden: cannot set an ownerRef on a resource you can't delete: , <nil>
E0118 17:47:43.678501       1 base_controller.go:270] "cluster-management-addon-controller" controller failed to sync "local-cluster/managed-serviceaccount", err: managedclusteraddons.addon.open-cluster-management.io "managed-serviceaccount" is forbidden: cannot set an ownerRef on a resource you can't delete: , <nil>
E0118 17:47:43.687662       1 base_controller.go:270] "cluster-management-addon-controller" controller failed to sync "nweather-managed/managed-serviceaccount", err: managedclusteraddons.addon.open-cluster-management.io "managed-serviceaccount" is forbidden: cannot set an ownerRef on a resource you can't delete: , <nil>
I0118 17:47:43.691345       1 event.go:282] Event(v1.ObjectReference{Kind:"Namespace", Namespace:"open-cluster-management-addon", Name:"open-cluster-management-addon", UID:"", APIVersion:"v1", ResourceVersion:"", FieldPath:""}): type: 'Warning' reason: 'ManifestWorkCreateFailed' Failed to create ManifestWork local-cluster/addon-managed-serviceaccount-deploy: manifestworks.work.open-cluster-management.io "addon-managed-serviceaccount-deploy" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
E0118 17:47:43.705948       1 base_controller.go:270] "addon-deploy-controller" controller failed to sync "local-cluster/managed-serviceaccount", err: manifestworks.work.open-cluster-management.io "addon-managed-serviceaccount-deploy" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
I0118 17:47:43.710181       1 event.go:282] Event(v1.ObjectReference{Kind:"Namespace", Namespace:"open-cluster-management-addon", Name:"open-cluster-management-addon", UID:"", APIVersion:"v1", ResourceVersion:"", FieldPath:""}): type: 'Warning' reason: 'ManifestWorkCreateFailed' Failed to create ManifestWork nweather-managed/addon-managed-serviceaccount-deploy: manifestworks.work.open-cluster-management.io "addon-managed-serviceaccount-deploy" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
E0118 17:47:43.717881       1 base_controller.go:270] "addon-deploy-controller" controller failed to sync "nweather-managed/managed-serviceaccount", err: manifestworks.work.open-cluster-management.io "addon-managed-serviceaccount-deploy" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
E0118 17:47:43.734109       1 base_controller.go:270] "addon-registration-controller" controller failed to sync "local-cluster/managed-serviceaccount", err: roles.rbac.authorization.k8s.io "managed-serviceaccount-addon-agent" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
E0118 17:47:43.803380       1 base_controller.go:270] "addon-registration-controller" controller failed to sync "nweather-managed/managed-serviceaccount", err: roles.rbac.authorization.k8s.io "managed-serviceaccount-addon-agent" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
E0118 17:54:38.656155       1 base_controller.go:270] "cluster-management-addon-controller" controller failed to sync "local-cluster/managed-serviceaccount", err: managedclusteraddons.addon.open-cluster-management.io "managed-serviceaccount" is forbidden: cannot set an ownerRef on a resource you can't delete: , <nil>
I0118 17:54:39.213353       1 event.go:282] Event(v1.ObjectReference{Kind:"Namespace", Namespace:"open-cluster-management-addon", Name:"open-cluster-management-addon", UID:"", APIVersion:"v1", ResourceVersion:"", FieldPath:""}): type: 'Warning' reason: 'ManifestWorkCreateFailed' Failed to create ManifestWork local-cluster/addon-managed-serviceaccount-deploy: manifestworks.work.open-cluster-management.io "addon-managed-serviceaccount-deploy" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
E0118 17:54:39.220997       1 base_controller.go:270] "addon-deploy-controller" controller failed to sync "local-cluster/managed-serviceaccount", err: manifestworks.work.open-cluster-management.io "addon-managed-serviceaccount-deploy" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
E0118 17:54:40.803795       1 base_controller.go:270] "addon-registration-controller" controller failed to sync "local-cluster/managed-serviceaccount", err: roles.rbac.authorization.k8s.io "managed-serviceaccount-addon-agent" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
E0118 17:55:17.076758       1 base_controller.go:270] "cluster-management-addon-controller" controller failed to sync "nweather-managed/managed-serviceaccount", err: managedclusteraddons.addon.open-cluster-management.io "managed-serviceaccount" is forbidden: cannot set an ownerRef on a resource you can't delete: , <nil>
I0118 17:55:17.816210       1 event.go:282] Event(v1.ObjectReference{Kind:"Namespace", Namespace:"open-cluster-management-addon", Name:"open-cluster-management-addon", UID:"", APIVersion:"v1", ResourceVersion:"", FieldPath:""}): type: 'Warning' reason: 'ManifestWorkCreateFailed' Failed to create ManifestWork nweather-managed/addon-managed-serviceaccount-deploy: manifestworks.work.open-cluster-management.io "addon-managed-serviceaccount-deploy" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
E0118 17:55:17.886803       1 base_controller.go:270] "addon-deploy-controller" controller failed to sync "nweather-managed/managed-serviceaccount", err: manifestworks.work.open-cluster-management.io "addon-managed-serviceaccount-deploy" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
E0118 17:55:19.327257       1 base_controller.go:270] "addon-registration-controller" controller failed to sync "nweather-managed/managed-serviceaccount", err: roles.rbac.authorization.k8s.io "managed-serviceaccount-addon-agent" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
E0118 17:57:43.653006       1 base_controller.go:270] "cluster-management-addon-controller" controller failed to sync "local-cluster/managed-serviceaccount", err: managedclusteraddons.addon.open-cluster-management.io "managed-serviceaccount" is forbidden: cannot set an ownerRef on a resource you can't delete: , <nil>
E0118 17:57:43.677158       1 base_controller.go:270] "cluster-management-addon-controller" controller failed to sync "nweather-managed/managed-serviceaccount", err: managedclusteraddons.addon.open-cluster-management.io "managed-serviceaccount" is forbidden: cannot set an ownerRef on a resource you can't delete: , <nil>
E0118 17:57:43.686802       1 base_controller.go:270] "cluster-management-addon-controller" controller failed to sync "local-cluster/managed-serviceaccount", err: managedclusteraddons.addon.open-cluster-management.io "managed-serviceaccount" is forbidden: cannot set an ownerRef on a resource you can't delete: , <nil>
I0118 17:57:43.690870       1 event.go:282] Event(v1.ObjectReference{Kind:"Namespace", Namespace:"open-cluster-management-addon", Name:"open-cluster-management-addon", UID:"", APIVersion:"v1", ResourceVersion:"", FieldPath:""}): type: 'Warning' reason: 'ManifestWorkCreateFailed' Failed to create ManifestWork local-cluster/addon-managed-serviceaccount-deploy: manifestworks.work.open-cluster-management.io "addon-managed-serviceaccount-deploy" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
E0118 17:57:43.694836       1 base_controller.go:270] "cluster-management-addon-controller" controller failed to sync "nweather-managed/managed-serviceaccount", err: managedclusteraddons.addon.open-cluster-management.io "managed-serviceaccount" is forbidden: cannot set an ownerRef on a resource you can't delete: , <nil>
E0118 17:57:43.699228       1 base_controller.go:270] "addon-deploy-controller" controller failed to sync "local-cluster/managed-serviceaccount", err: manifestworks.work.open-cluster-management.io "addon-managed-serviceaccount-deploy" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
I0118 17:57:43.703948       1 event.go:282] Event(v1.ObjectReference{Kind:"Namespace", Namespace:"open-cluster-management-addon", Name:"open-cluster-management-addon", UID:"", APIVersion:"v1", ResourceVersion:"", FieldPath:""}): type: 'Warning' reason: 'ManifestWorkCreateFailed' Failed to create ManifestWork nweather-managed/addon-managed-serviceaccount-deploy: manifestworks.work.open-cluster-management.io "addon-managed-serviceaccount-deploy" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
E0118 17:57:43.715502       1 base_controller.go:270] "addon-deploy-controller" controller failed to sync "nweather-managed/managed-serviceaccount", err: manifestworks.work.open-cluster-management.io "addon-managed-serviceaccount-deploy" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
E0118 17:57:43.740366       1 base_controller.go:270] "addon-registration-controller" controller failed to sync "local-cluster/managed-serviceaccount", err: roles.rbac.authorization.k8s.io "managed-serviceaccount-addon-agent" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
E0118 17:57:43.814067       1 base_controller.go:270] "addon-registration-controller" controller failed to sync "nweather-managed/managed-serviceaccount", err: roles.rbac.authorization.k8s.io "managed-serviceaccount-addon-agent" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
E0118 18:07:43.670382       1 base_controller.go:270] "cluster-management-addon-controller" controller failed to sync "nweather-managed/managed-serviceaccount", err: managedclusteraddons.addon.open-cluster-management.io "managed-serviceaccount" is forbidden: cannot set an ownerRef on a resource you can't delete: , <nil>
E0118 18:07:43.680026       1 base_controller.go:270] "cluster-management-addon-controller" controller failed to sync "local-cluster/managed-serviceaccount", err: managedclusteraddons.addon.open-cluster-management.io "managed-serviceaccount" is forbidden: cannot set an ownerRef on a resource you can't delete: , <nil>
I0118 18:07:43.680780       1 event.go:282] Event(v1.ObjectReference{Kind:"Namespace", Namespace:"open-cluster-management-addon", Name:"open-cluster-management-addon", UID:"", APIVersion:"v1", ResourceVersion:"", FieldPath:""}): type: 'Warning' reason: 'ManifestWorkCreateFailed' Failed to create ManifestWork nweather-managed/addon-managed-serviceaccount-deploy: manifestworks.work.open-cluster-management.io "addon-managed-serviceaccount-deploy" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
E0118 18:07:43.688555       1 base_controller.go:270] "addon-deploy-controller" controller failed to sync "nweather-managed/managed-serviceaccount", err: manifestworks.work.open-cluster-management.io "addon-managed-serviceaccount-deploy" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
E0118 18:07:43.688703       1 base_controller.go:270] "cluster-management-addon-controller" controller failed to sync "local-cluster/managed-serviceaccount", err: managedclusteraddons.addon.open-cluster-management.io "managed-serviceaccount" is forbidden: cannot set an ownerRef on a resource you can't delete: , <nil>
I0118 18:07:43.692704       1 event.go:282] Event(v1.ObjectReference{Kind:"Namespace", Namespace:"open-cluster-management-addon", Name:"open-cluster-management-addon", UID:"", APIVersion:"v1", ResourceVersion:"", FieldPath:""}): type: 'Warning' reason: 'ManifestWorkCreateFailed' Failed to create ManifestWork local-cluster/addon-managed-serviceaccount-deploy: manifestworks.work.open-cluster-management.io "addon-managed-serviceaccount-deploy" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
E0118 18:07:43.697799       1 base_controller.go:270] "cluster-management-addon-controller" controller failed to sync "nweather-managed/managed-serviceaccount", err: managedclusteraddons.addon.open-cluster-management.io "managed-serviceaccount" is forbidden: cannot set an ownerRef on a resource you can't delete: , <nil>
E0118 18:07:43.703487       1 base_controller.go:270] "addon-deploy-controller" controller failed to sync "local-cluster/managed-serviceaccount", err: manifestworks.work.open-cluster-management.io "addon-managed-serviceaccount-deploy" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
E0118 18:07:43.730619       1 base_controller.go:270] "addon-registration-controller" controller failed to sync "nweather-managed/managed-serviceaccount", err: roles.rbac.authorization.k8s.io "managed-serviceaccount-addon-agent" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
E0118 18:07:43.792772       1 base_controller.go:270] "addon-registration-controller" controller failed to sync "local-cluster/managed-serviceaccount", err: roles.rbac.authorization.k8s.io "managed-serviceaccount-addon-agent" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
E0118 18:11:18.665857       1 base_controller.go:270] "cluster-management-addon-controller" controller failed to sync "local-cluster/managed-serviceaccount", err: managedclusteraddons.addon.open-cluster-management.io "managed-serviceaccount" is forbidden: cannot set an ownerRef on a resource you can't delete: , <nil>
I0118 18:11:19.259116       1 event.go:282] Event(v1.ObjectReference{Kind:"Namespace", Namespace:"open-cluster-management-addon", Name:"open-cluster-management-addon", UID:"", APIVersion:"v1", ResourceVersion:"", FieldPath:""}): type: 'Warning' reason: 'ManifestWorkCreateFailed' Failed to create ManifestWork local-cluster/addon-managed-serviceaccount-deploy: manifestworks.work.open-cluster-management.io "addon-managed-serviceaccount-deploy" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
E0118 18:11:19.268428       1 base_controller.go:270] "addon-deploy-controller" controller failed to sync "local-cluster/managed-serviceaccount", err: manifestworks.work.open-cluster-management.io "addon-managed-serviceaccount-deploy" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
E0118 18:11:20.883937       1 base_controller.go:270] "addon-registration-controller" controller failed to sync "local-cluster/managed-serviceaccount", err: roles.rbac.authorization.k8s.io "managed-serviceaccount-addon-agent" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
E0118 18:11:57.088925       1 base_controller.go:270] "cluster-management-addon-controller" controller failed to sync "nweather-managed/managed-serviceaccount", err: managedclusteraddons.addon.open-cluster-management.io "managed-serviceaccount" is forbidden: cannot set an ownerRef on a resource you can't delete: , <nil>
I0118 18:11:58.313088       1 event.go:282] Event(v1.ObjectReference{Kind:"Namespace", Namespace:"open-cluster-management-addon", Name:"open-cluster-management-addon", UID:"", APIVersion:"v1", ResourceVersion:"", FieldPath:""}): type: 'Warning' reason: 'ManifestWorkCreateFailed' Failed to create ManifestWork nweather-managed/addon-managed-serviceaccount-deploy: manifestworks.work.open-cluster-management.io "addon-managed-serviceaccount-deploy" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
E0118 18:11:58.319873       1 base_controller.go:270] "addon-deploy-controller" controller failed to sync "nweather-managed/managed-serviceaccount", err: manifestworks.work.open-cluster-management.io "addon-managed-serviceaccount-deploy" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
E0118 18:11:59.390568       1 base_controller.go:270] "addon-registration-controller" controller failed to sync "nweather-managed/managed-serviceaccount", err: roles.rbac.authorization.k8s.io "managed-serviceaccount-addon-agent" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
E0118 18:17:43.657648       1 base_controller.go:270] "cluster-management-addon-controller" controller failed to sync "local-cluster/managed-serviceaccount", err: managedclusteraddons.addon.open-cluster-management.io "managed-serviceaccount" is forbidden: cannot set an ownerRef on a resource you can't delete: , <nil>
E0118 18:17:43.692395       1 base_controller.go:270] "cluster-management-addon-controller" controller failed to sync "nweather-managed/managed-serviceaccount", err: managedclusteraddons.addon.open-cluster-management.io "managed-serviceaccount" is forbidden: cannot set an ownerRef on a resource you can't delete: , <nil>
I0118 18:17:43.699987       1 event.go:282] Event(v1.ObjectReference{Kind:"Namespace", Namespace:"open-cluster-management-addon", Name:"open-cluster-management-addon", UID:"", APIVersion:"v1", ResourceVersion:"", FieldPath:""}): type: 'Warning' reason: 'ManifestWorkCreateFailed' Failed to create ManifestWork local-cluster/addon-managed-serviceaccount-deploy: manifestworks.work.open-cluster-management.io "addon-managed-serviceaccount-deploy" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
E0118 18:17:43.702311       1 base_controller.go:270] "cluster-management-addon-controller" controller failed to sync "local-cluster/managed-serviceaccount", err: managedclusteraddons.addon.open-cluster-management.io "managed-serviceaccount" is forbidden: cannot set an ownerRef on a resource you can't delete: , <nil>
E0118 18:17:43.707684       1 base_controller.go:270] "addon-deploy-controller" controller failed to sync "local-cluster/managed-serviceaccount", err: manifestworks.work.open-cluster-management.io "addon-managed-serviceaccount-deploy" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
E0118 18:17:43.709924       1 base_controller.go:270] "cluster-management-addon-controller" controller failed to sync "nweather-managed/managed-serviceaccount", err: managedclusteraddons.addon.open-cluster-management.io "managed-serviceaccount" is forbidden: cannot set an ownerRef on a resource you can't delete: , <nil>
I0118 18:17:43.711843       1 event.go:282] Event(v1.ObjectReference{Kind:"Namespace", Namespace:"open-cluster-management-addon", Name:"open-cluster-management-addon", UID:"", APIVersion:"v1", ResourceVersion:"", FieldPath:""}): type: 'Warning' reason: 'ManifestWorkCreateFailed' Failed to create ManifestWork nweather-managed/addon-managed-serviceaccount-deploy: manifestworks.work.open-cluster-management.io "addon-managed-serviceaccount-deploy" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
E0118 18:17:43.718981       1 base_controller.go:270] "addon-deploy-controller" controller failed to sync "nweather-managed/managed-serviceaccount", err: manifestworks.work.open-cluster-management.io "addon-managed-serviceaccount-deploy" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
E0118 18:17:43.772876       1 base_controller.go:270] "addon-registration-controller" controller failed to sync "local-cluster/managed-serviceaccount", err: roles.rbac.authorization.k8s.io "managed-serviceaccount-addon-agent" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
E0118 18:17:43.903440       1 base_controller.go:270] "addon-registration-controller" controller failed to sync "nweather-managed/managed-serviceaccount", err: roles.rbac.authorization.k8s.io "managed-serviceaccount-addon-agent" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
E0118 18:27:43.652765       1 base_controller.go:270] "cluster-management-addon-controller" controller failed to sync "local-cluster/managed-serviceaccount", err: managedclusteraddons.addon.open-cluster-management.io "managed-serviceaccount" is forbidden: cannot set an ownerRef on a resource you can't delete: , <nil>
E0118 18:27:43.667415       1 base_controller.go:270] "cluster-management-addon-controller" controller failed to sync "nweather-managed/managed-serviceaccount", err: managedclusteraddons.addon.open-cluster-management.io "managed-serviceaccount" is forbidden: cannot set an ownerRef on a resource you can't delete: , <nil>
E0118 18:27:43.680112       1 base_controller.go:270] "cluster-management-addon-controller" controller failed to sync "local-cluster/managed-serviceaccount", err: managedclusteraddons.addon.open-cluster-management.io "managed-serviceaccount" is forbidden: cannot set an ownerRef on a resource you can't delete: , <nil>
E0118 18:27:43.687753       1 base_controller.go:270] "cluster-management-addon-controller" controller failed to sync "nweather-managed/managed-serviceaccount", err: managedclusteraddons.addon.open-cluster-management.io "managed-serviceaccount" is forbidden: cannot set an ownerRef on a resource you can't delete: , <nil>
I0118 18:27:43.692361       1 event.go:282] Event(v1.ObjectReference{Kind:"Namespace", Namespace:"open-cluster-management-addon", Name:"open-cluster-management-addon", UID:"", APIVersion:"v1", ResourceVersion:"", FieldPath:""}): type: 'Warning' reason: 'ManifestWorkCreateFailed' Failed to create ManifestWork local-cluster/addon-managed-serviceaccount-deploy: manifestworks.work.open-cluster-management.io "addon-managed-serviceaccount-deploy" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
E0118 18:27:43.705615       1 base_controller.go:270] "addon-deploy-controller" controller failed to sync "local-cluster/managed-serviceaccount", err: manifestworks.work.open-cluster-management.io "addon-managed-serviceaccount-deploy" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
I0118 18:27:43.712393       1 event.go:282] Event(v1.ObjectReference{Kind:"Namespace", Namespace:"open-cluster-management-addon", Name:"open-cluster-management-addon", UID:"", APIVersion:"v1", ResourceVersion:"", FieldPath:""}): type: 'Warning' reason: 'ManifestWorkCreateFailed' Failed to create ManifestWork nweather-managed/addon-managed-serviceaccount-deploy: manifestworks.work.open-cluster-management.io "addon-managed-serviceaccount-deploy" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
E0118 18:27:43.722713       1 base_controller.go:270] "addon-deploy-controller" controller failed to sync "nweather-managed/managed-serviceaccount", err: manifestworks.work.open-cluster-management.io "addon-managed-serviceaccount-deploy" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
E0118 18:27:43.732101       1 base_controller.go:270] "addon-registration-controller" controller failed to sync "local-cluster/managed-serviceaccount", err: roles.rbac.authorization.k8s.io "managed-serviceaccount-addon-agent" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
E0118 18:27:43.792967       1 base_controller.go:270] "addon-registration-controller" controller failed to sync "nweather-managed/managed-serviceaccount", err: roles.rbac.authorization.k8s.io "managed-serviceaccount-addon-agent" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
E0118 18:27:58.674004       1 base_controller.go:270] "cluster-management-addon-controller" controller failed to sync "local-cluster/managed-serviceaccount", err: managedclusteraddons.addon.open-cluster-management.io "managed-serviceaccount" is forbidden: cannot set an ownerRef on a resource you can't delete: , <nil>
I0118 18:27:59.306005       1 event.go:282] Event(v1.ObjectReference{Kind:"Namespace", Namespace:"open-cluster-management-addon", Name:"open-cluster-management-addon", UID:"", APIVersion:"v1", ResourceVersion:"", FieldPath:""}): type: 'Warning' reason: 'ManifestWorkCreateFailed' Failed to create ManifestWork local-cluster/addon-managed-serviceaccount-deploy: manifestworks.work.open-cluster-management.io "addon-managed-serviceaccount-deploy" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
E0118 18:27:59.313205       1 base_controller.go:270] "addon-deploy-controller" controller failed to sync "local-cluster/managed-serviceaccount", err: manifestworks.work.open-cluster-management.io "addon-managed-serviceaccount-deploy" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
E0118 18:28:00.961729       1 base_controller.go:270] "addon-registration-controller" controller failed to sync "local-cluster/managed-serviceaccount", err: roles.rbac.authorization.k8s.io "managed-serviceaccount-addon-agent" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
E0118 18:28:37.096819       1 base_controller.go:270] "cluster-management-addon-controller" controller failed to sync "nweather-managed/managed-serviceaccount", err: managedclusteraddons.addon.open-cluster-management.io "managed-serviceaccount" is forbidden: cannot set an ownerRef on a resource you can't delete: , <nil>
I0118 18:28:38.363174       1 event.go:282] Event(v1.ObjectReference{Kind:"Namespace", Namespace:"open-cluster-management-addon", Name:"open-cluster-management-addon", UID:"", APIVersion:"v1", ResourceVersion:"", FieldPath:""}): type: 'Warning' reason: 'ManifestWorkCreateFailed' Failed to create ManifestWork nweather-managed/addon-managed-serviceaccount-deploy: manifestworks.work.open-cluster-management.io "addon-managed-serviceaccount-deploy" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
E0118 18:28:38.375428       1 base_controller.go:270] "addon-deploy-controller" controller failed to sync "nweather-managed/managed-serviceaccount", err: manifestworks.work.open-cluster-management.io "addon-managed-serviceaccount-deploy" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
E0118 18:28:39.476446       1 base_controller.go:270] "addon-registration-controller" controller failed to sync "nweather-managed/managed-serviceaccount", err: roles.rbac.authorization.k8s.io "managed-serviceaccount-addon-agent" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
E0118 18:37:43.661757       1 base_controller.go:270] "cluster-management-addon-controller" controller failed to sync "local-cluster/managed-serviceaccount", err: managedclusteraddons.addon.open-cluster-management.io "managed-serviceaccount" is forbidden: cannot set an ownerRef on a resource you can't delete: , <nil>
E0118 18:37:43.674051       1 base_controller.go:270] "cluster-management-addon-controller" controller failed to sync "nweather-managed/managed-serviceaccount", err: managedclusteraddons.addon.open-cluster-management.io "managed-serviceaccount" is forbidden: cannot set an ownerRef on a resource you can't delete: , <nil>
E0118 18:37:43.681608       1 base_controller.go:270] "cluster-management-addon-controller" controller failed to sync "nweather-managed/managed-serviceaccount", err: managedclusteraddons.addon.open-cluster-management.io "managed-serviceaccount" is forbidden: cannot set an ownerRef on a resource you can't delete: , <nil>
I0118 18:37:43.685811       1 event.go:282] Event(v1.ObjectReference{Kind:"Namespace", Namespace:"open-cluster-management-addon", Name:"open-cluster-management-addon", UID:"", APIVersion:"v1", ResourceVersion:"", FieldPath:""}): type: 'Warning' reason: 'ManifestWorkCreateFailed' Failed to create ManifestWork local-cluster/addon-managed-serviceaccount-deploy: manifestworks.work.open-cluster-management.io "addon-managed-serviceaccount-deploy" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
E0118 18:37:43.688358       1 base_controller.go:270] "cluster-management-addon-controller" controller failed to sync "local-cluster/managed-serviceaccount", err: managedclusteraddons.addon.open-cluster-management.io "managed-serviceaccount" is forbidden: cannot set an ownerRef on a resource you can't delete: , <nil>
E0118 18:37:43.693815       1 base_controller.go:270] "addon-deploy-controller" controller failed to sync "local-cluster/managed-serviceaccount", err: manifestworks.work.open-cluster-management.io "addon-managed-serviceaccount-deploy" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
I0118 18:37:43.697262       1 event.go:282] Event(v1.ObjectReference{Kind:"Namespace", Namespace:"open-cluster-management-addon", Name:"open-cluster-management-addon", UID:"", APIVersion:"v1", ResourceVersion:"", FieldPath:""}): type: 'Warning' reason: 'ManifestWorkCreateFailed' Failed to create ManifestWork nweather-managed/addon-managed-serviceaccount-deploy: manifestworks.work.open-cluster-management.io "addon-managed-serviceaccount-deploy" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
E0118 18:37:43.707353       1 base_controller.go:270] "addon-deploy-controller" controller failed to sync "nweather-managed/managed-serviceaccount", err: manifestworks.work.open-cluster-management.io "addon-managed-serviceaccount-deploy" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
E0118 18:37:43.747542       1 base_controller.go:270] "addon-registration-controller" controller failed to sync "local-cluster/managed-serviceaccount", err: roles.rbac.authorization.k8s.io "managed-serviceaccount-addon-agent" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
E0118 18:37:43.833549       1 base_controller.go:270] "addon-registration-controller" controller failed to sync "nweather-managed/managed-serviceaccount", err: roles.rbac.authorization.k8s.io "managed-serviceaccount-addon-agent" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
E0118 18:44:38.681599       1 base_controller.go:270] "cluster-management-addon-controller" controller failed to sync "local-cluster/managed-serviceaccount", err: managedclusteraddons.addon.open-cluster-management.io "managed-serviceaccount" is forbidden: cannot set an ownerRef on a resource you can't delete: , <nil>
I0118 18:44:39.350711       1 event.go:282] Event(v1.ObjectReference{Kind:"Namespace", Namespace:"open-cluster-management-addon", Name:"open-cluster-management-addon", UID:"", APIVersion:"v1", ResourceVersion:"", FieldPath:""}): type: 'Warning' reason: 'ManifestWorkCreateFailed' Failed to create ManifestWork local-cluster/addon-managed-serviceaccount-deploy: manifestworks.work.open-cluster-management.io "addon-managed-serviceaccount-deploy" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
E0118 18:44:39.357728       1 base_controller.go:270] "addon-deploy-controller" controller failed to sync "local-cluster/managed-serviceaccount", err: manifestworks.work.open-cluster-management.io "addon-managed-serviceaccount-deploy" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
E0118 18:44:41.023769       1 base_controller.go:270] "addon-registration-controller" controller failed to sync "local-cluster/managed-serviceaccount", err: roles.rbac.authorization.k8s.io "managed-serviceaccount-addon-agent" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
E0118 18:45:17.111644       1 base_controller.go:270] "cluster-management-addon-controller" controller failed to sync "nweather-managed/managed-serviceaccount", err: managedclusteraddons.addon.open-cluster-management.io "managed-serviceaccount" is forbidden: cannot set an ownerRef on a resource you can't delete: , <nil>
I0118 18:45:18.429342       1 event.go:282] Event(v1.ObjectReference{Kind:"Namespace", Namespace:"open-cluster-management-addon", Name:"open-cluster-management-addon", UID:"", APIVersion:"v1", ResourceVersion:"", FieldPath:""}): type: 'Warning' reason: 'ManifestWorkCreateFailed' Failed to create ManifestWork nweather-managed/addon-managed-serviceaccount-deploy: manifestworks.work.open-cluster-management.io "addon-managed-serviceaccount-deploy" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
E0118 18:45:18.440316       1 base_controller.go:270] "addon-deploy-controller" controller failed to sync "nweather-managed/managed-serviceaccount", err: manifestworks.work.open-cluster-management.io "addon-managed-serviceaccount-deploy" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
E0118 18:45:19.579856       1 base_controller.go:270] "addon-registration-controller" controller failed to sync "nweather-managed/managed-serviceaccount", err: roles.rbac.authorization.k8s.io "managed-serviceaccount-addon-agent" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
E0118 18:47:43.665723       1 base_controller.go:270] "cluster-management-addon-controller" controller failed to sync "local-cluster/managed-serviceaccount", err: managedclusteraddons.addon.open-cluster-management.io "managed-serviceaccount" is forbidden: cannot set an ownerRef on a resource you can't delete: , <nil>
E0118 18:47:43.678786       1 base_controller.go:270] "cluster-management-addon-controller" controller failed to sync "nweather-managed/managed-serviceaccount", err: managedclusteraddons.addon.open-cluster-management.io "managed-serviceaccount" is forbidden: cannot set an ownerRef on a resource you can't delete: , <nil>
I0118 18:47:43.695963       1 event.go:282] Event(v1.ObjectReference{Kind:"Namespace", Namespace:"open-cluster-management-addon", Name:"open-cluster-management-addon", UID:"", APIVersion:"v1", ResourceVersion:"", FieldPath:""}): type: 'Warning' reason: 'ManifestWorkCreateFailed' Failed to create ManifestWork local-cluster/addon-managed-serviceaccount-deploy: manifestworks.work.open-cluster-management.io "addon-managed-serviceaccount-deploy" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
E0118 18:47:43.705414       1 base_controller.go:270] "cluster-management-addon-controller" controller failed to sync "local-cluster/managed-serviceaccount", err: managedclusteraddons.addon.open-cluster-management.io "managed-serviceaccount" is forbidden: cannot set an ownerRef on a resource you can't delete: , <nil>
E0118 18:47:43.714123       1 base_controller.go:270] "addon-deploy-controller" controller failed to sync "local-cluster/managed-serviceaccount", err: manifestworks.work.open-cluster-management.io "addon-managed-serviceaccount-deploy" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
I0118 18:47:43.718602       1 event.go:282] Event(v1.ObjectReference{Kind:"Namespace", Namespace:"open-cluster-management-addon", Name:"open-cluster-management-addon", UID:"", APIVersion:"v1", ResourceVersion:"", FieldPath:""}): type: 'Warning' reason: 'ManifestWorkCreateFailed' Failed to create ManifestWork nweather-managed/addon-managed-serviceaccount-deploy: manifestworks.work.open-cluster-management.io "addon-managed-serviceaccount-deploy" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
E0118 18:47:43.728779       1 base_controller.go:270] "addon-deploy-controller" controller failed to sync "nweather-managed/managed-serviceaccount", err: manifestworks.work.open-cluster-management.io "addon-managed-serviceaccount-deploy" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
E0118 18:47:43.785540       1 base_controller.go:270] "addon-registration-controller" controller failed to sync "local-cluster/managed-serviceaccount", err: roles.rbac.authorization.k8s.io "managed-serviceaccount-addon-agent" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
E0118 18:47:43.877985       1 base_controller.go:270] "addon-registration-controller" controller failed to sync "nweather-managed/managed-serviceaccount", err: roles.rbac.authorization.k8s.io "managed-serviceaccount-addon-agent" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
E0118 18:57:43.674435       1 base_controller.go:270] "cluster-management-addon-controller" controller failed to sync "nweather-managed/managed-serviceaccount", err: managedclusteraddons.addon.open-cluster-management.io "managed-serviceaccount" is forbidden: cannot set an ownerRef on a resource you can't delete: , <nil>
E0118 18:57:43.682019       1 base_controller.go:270] "cluster-management-addon-controller" controller failed to sync "local-cluster/managed-serviceaccount", err: managedclusteraddons.addon.open-cluster-management.io "managed-serviceaccount" is forbidden: cannot set an ownerRef on a resource you can't delete: , <nil>
E0118 18:57:43.691678       1 base_controller.go:270] "cluster-management-addon-controller" controller failed to sync "nweather-managed/managed-serviceaccount", err: managedclusteraddons.addon.open-cluster-management.io "managed-serviceaccount" is forbidden: cannot set an ownerRef on a resource you can't delete: , <nil>
I0118 18:57:43.691710       1 event.go:282] Event(v1.ObjectReference{Kind:"Namespace", Namespace:"open-cluster-management-addon", Name:"open-cluster-management-addon", UID:"", APIVersion:"v1", ResourceVersion:"", FieldPath:""}): type: 'Warning' reason: 'ManifestWorkCreateFailed' Failed to create ManifestWork local-cluster/addon-managed-serviceaccount-deploy: manifestworks.work.open-cluster-management.io "addon-managed-serviceaccount-deploy" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
E0118 18:57:43.700472       1 base_controller.go:270] "addon-deploy-controller" controller failed to sync "local-cluster/managed-serviceaccount", err: manifestworks.work.open-cluster-management.io "addon-managed-serviceaccount-deploy" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
I0118 18:57:43.704771       1 event.go:282] Event(v1.ObjectReference{Kind:"Namespace", Namespace:"open-cluster-management-addon", Name:"open-cluster-management-addon", UID:"", APIVersion:"v1", ResourceVersion:"", FieldPath:""}): type: 'Warning' reason: 'ManifestWorkCreateFailed' Failed to create ManifestWork nweather-managed/addon-managed-serviceaccount-deploy: manifestworks.work.open-cluster-management.io "addon-managed-serviceaccount-deploy" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
E0118 18:57:43.712581       1 base_controller.go:270] "addon-deploy-controller" controller failed to sync "nweather-managed/managed-serviceaccount", err: manifestworks.work.open-cluster-management.io "addon-managed-serviceaccount-deploy" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
E0118 18:57:43.743892       1 base_controller.go:270] "addon-registration-controller" controller failed to sync "local-cluster/managed-serviceaccount", err: roles.rbac.authorization.k8s.io "managed-serviceaccount-addon-agent" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
E0118 18:57:43.815097       1 base_controller.go:270] "addon-registration-controller" controller failed to sync "nweather-managed/managed-serviceaccount", err: roles.rbac.authorization.k8s.io "managed-serviceaccount-addon-agent" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
E0118 19:01:18.691166       1 base_controller.go:270] "cluster-management-addon-controller" controller failed to sync "local-cluster/managed-serviceaccount", err: managedclusteraddons.addon.open-cluster-management.io "managed-serviceaccount" is forbidden: cannot set an ownerRef on a resource you can't delete: , <nil>
I0118 19:01:19.394922       1 event.go:282] Event(v1.ObjectReference{Kind:"Namespace", Namespace:"open-cluster-management-addon", Name:"open-cluster-management-addon", UID:"", APIVersion:"v1", ResourceVersion:"", FieldPath:""}): type: 'Warning' reason: 'ManifestWorkCreateFailed' Failed to create ManifestWork local-cluster/addon-managed-serviceaccount-deploy: manifestworks.work.open-cluster-management.io "addon-managed-serviceaccount-deploy" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
E0118 19:01:19.402487       1 base_controller.go:270] "addon-deploy-controller" controller failed to sync "local-cluster/managed-serviceaccount", err: manifestworks.work.open-cluster-management.io "addon-managed-serviceaccount-deploy" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
E0118 19:01:21.185844       1 base_controller.go:270] "addon-registration-controller" controller failed to sync "local-cluster/managed-serviceaccount", err: roles.rbac.authorization.k8s.io "managed-serviceaccount-addon-agent" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
E0118 19:01:57.120037       1 base_controller.go:270] "cluster-management-addon-controller" controller failed to sync "nweather-managed/managed-serviceaccount", err: managedclusteraddons.addon.open-cluster-management.io "managed-serviceaccount" is forbidden: cannot set an ownerRef on a resource you can't delete: , <nil>
I0118 19:01:58.489953       1 event.go:282] Event(v1.ObjectReference{Kind:"Namespace", Namespace:"open-cluster-management-addon", Name:"open-cluster-management-addon", UID:"", APIVersion:"v1", ResourceVersion:"", FieldPath:""}): type: 'Warning' reason: 'ManifestWorkCreateFailed' Failed to create ManifestWork nweather-managed/addon-managed-serviceaccount-deploy: manifestworks.work.open-cluster-management.io "addon-managed-serviceaccount-deploy" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
E0118 19:01:58.498863       1 base_controller.go:270] "addon-deploy-controller" controller failed to sync "nweather-managed/managed-serviceaccount", err: manifestworks.work.open-cluster-management.io "addon-managed-serviceaccount-deploy" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
E0118 19:01:59.660035       1 base_controller.go:270] "addon-registration-controller" controller failed to sync "nweather-managed/managed-serviceaccount", err: roles.rbac.authorization.k8s.io "managed-serviceaccount-addon-agent" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
E0118 19:07:43.666943       1 base_controller.go:270] "cluster-management-addon-controller" controller failed to sync "nweather-managed/managed-serviceaccount", err: managedclusteraddons.addon.open-cluster-management.io "managed-serviceaccount" is forbidden: cannot set an ownerRef on a resource you can't delete: , <nil>
E0118 19:07:43.676411       1 base_controller.go:270] "cluster-management-addon-controller" controller failed to sync "local-cluster/managed-serviceaccount", err: managedclusteraddons.addon.open-cluster-management.io "managed-serviceaccount" is forbidden: cannot set an ownerRef on a resource you can't delete: , <nil>
E0118 19:07:43.692968       1 base_controller.go:270] "cluster-management-addon-controller" controller failed to sync "nweather-managed/managed-serviceaccount", err: managedclusteraddons.addon.open-cluster-management.io "managed-serviceaccount" is forbidden: cannot set an ownerRef on a resource you can't delete: , <nil>
I0118 19:07:43.701113       1 event.go:282] Event(v1.ObjectReference{Kind:"Namespace", Namespace:"open-cluster-management-addon", Name:"open-cluster-management-addon", UID:"", APIVersion:"v1", ResourceVersion:"", FieldPath:""}): type: 'Warning' reason: 'ManifestWorkCreateFailed' Failed to create ManifestWork local-cluster/addon-managed-serviceaccount-deploy: manifestworks.work.open-cluster-management.io "addon-managed-serviceaccount-deploy" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
E0118 19:07:43.712909       1 base_controller.go:270] "addon-deploy-controller" controller failed to sync "local-cluster/managed-serviceaccount", err: manifestworks.work.open-cluster-management.io "addon-managed-serviceaccount-deploy" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
I0118 19:07:43.717094       1 event.go:282] Event(v1.ObjectReference{Kind:"Namespace", Namespace:"open-cluster-management-addon", Name:"open-cluster-management-addon", UID:"", APIVersion:"v1", ResourceVersion:"", FieldPath:""}): type: 'Warning' reason: 'ManifestWorkCreateFailed' Failed to create ManifestWork nweather-managed/addon-managed-serviceaccount-deploy: manifestworks.work.open-cluster-management.io "addon-managed-serviceaccount-deploy" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
E0118 19:07:43.730839       1 base_controller.go:270] "addon-deploy-controller" controller failed to sync "nweather-managed/managed-serviceaccount", err: manifestworks.work.open-cluster-management.io "addon-managed-serviceaccount-deploy" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
E0118 19:07:43.775518       1 base_controller.go:270] "addon-registration-controller" controller failed to sync "local-cluster/managed-serviceaccount", err: roles.rbac.authorization.k8s.io "managed-serviceaccount-addon-agent" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
E0118 19:07:43.843660       1 base_controller.go:270] "addon-registration-controller" controller failed to sync "nweather-managed/managed-serviceaccount", err: roles.rbac.authorization.k8s.io "managed-serviceaccount-addon-agent" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
E0118 19:17:43.656528       1 base_controller.go:270] "cluster-management-addon-controller" controller failed to sync "local-cluster/managed-serviceaccount", err: managedclusteraddons.addon.open-cluster-management.io "managed-serviceaccount" is forbidden: cannot set an ownerRef on a resource you can't delete: , <nil>
E0118 19:17:43.667330       1 base_controller.go:270] "cluster-management-addon-controller" controller failed to sync "nweather-managed/managed-serviceaccount", err: managedclusteraddons.addon.open-cluster-management.io "managed-serviceaccount" is forbidden: cannot set an ownerRef on a resource you can't delete: , <nil>
E0118 19:17:43.675309       1 base_controller.go:270] "cluster-management-addon-controller" controller failed to sync "local-cluster/managed-serviceaccount", err: managedclusteraddons.addon.open-cluster-management.io "managed-serviceaccount" is forbidden: cannot set an ownerRef on a resource you can't delete: , <nil>
I0118 19:17:43.699606       1 event.go:282] Event(v1.ObjectReference{Kind:"Namespace", Namespace:"open-cluster-management-addon", Name:"open-cluster-management-addon", UID:"", APIVersion:"v1", ResourceVersion:"", FieldPath:""}): type: 'Warning' reason: 'ManifestWorkCreateFailed' Failed to create ManifestWork nweather-managed/addon-managed-serviceaccount-deploy: manifestworks.work.open-cluster-management.io "addon-managed-serviceaccount-deploy" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
E0118 19:17:43.709395       1 base_controller.go:270] "addon-deploy-controller" controller failed to sync "nweather-managed/managed-serviceaccount", err: manifestworks.work.open-cluster-management.io "addon-managed-serviceaccount-deploy" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
I0118 19:17:43.714081       1 event.go:282] Event(v1.ObjectReference{Kind:"Namespace", Namespace:"open-cluster-management-addon", Name:"open-cluster-management-addon", UID:"", APIVersion:"v1", ResourceVersion:"", FieldPath:""}): type: 'Warning' reason: 'ManifestWorkCreateFailed' Failed to create ManifestWork local-cluster/addon-managed-serviceaccount-deploy: manifestworks.work.open-cluster-management.io "addon-managed-serviceaccount-deploy" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
E0118 19:17:43.722524       1 base_controller.go:270] "addon-deploy-controller" controller failed to sync "local-cluster/managed-serviceaccount", err: manifestworks.work.open-cluster-management.io "addon-managed-serviceaccount-deploy" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
E0118 19:17:43.744445       1 base_controller.go:270] "addon-registration-controller" controller failed to sync "nweather-managed/managed-serviceaccount", err: roles.rbac.authorization.k8s.io "managed-serviceaccount-addon-agent" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
E0118 19:17:43.813829       1 base_controller.go:270] "addon-registration-controller" controller failed to sync "local-cluster/managed-serviceaccount", err: roles.rbac.authorization.k8s.io "managed-serviceaccount-addon-agent" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
E0118 19:17:58.701168       1 base_controller.go:270] "cluster-management-addon-controller" controller failed to sync "local-cluster/managed-serviceaccount", err: managedclusteraddons.addon.open-cluster-management.io "managed-serviceaccount" is forbidden: cannot set an ownerRef on a resource you can't delete: , <nil>
I0118 19:17:59.451306       1 event.go:282] Event(v1.ObjectReference{Kind:"Namespace", Namespace:"open-cluster-management-addon", Name:"open-cluster-management-addon", UID:"", APIVersion:"v1", ResourceVersion:"", FieldPath:""}): type: 'Warning' reason: 'ManifestWorkCreateFailed' Failed to create ManifestWork local-cluster/addon-managed-serviceaccount-deploy: manifestworks.work.open-cluster-management.io "addon-managed-serviceaccount-deploy" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
E0118 19:17:59.460000       1 base_controller.go:270] "addon-deploy-controller" controller failed to sync "local-cluster/managed-serviceaccount", err: manifestworks.work.open-cluster-management.io "addon-managed-serviceaccount-deploy" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
E0118 19:18:01.258870       1 base_controller.go:270] "addon-registration-controller" controller failed to sync "local-cluster/managed-serviceaccount", err: roles.rbac.authorization.k8s.io "managed-serviceaccount-addon-agent" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
E0118 19:18:37.127384       1 base_controller.go:270] "cluster-management-addon-controller" controller failed to sync "nweather-managed/managed-serviceaccount", err: managedclusteraddons.addon.open-cluster-management.io "managed-serviceaccount" is forbidden: cannot set an ownerRef on a resource you can't delete: , <nil>
I0118 19:18:38.538646       1 event.go:282] Event(v1.ObjectReference{Kind:"Namespace", Namespace:"open-cluster-management-addon", Name:"open-cluster-management-addon", UID:"", APIVersion:"v1", ResourceVersion:"", FieldPath:""}): type: 'Warning' reason: 'ManifestWorkCreateFailed' Failed to create ManifestWork nweather-managed/addon-managed-serviceaccount-deploy: manifestworks.work.open-cluster-management.io "addon-managed-serviceaccount-deploy" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
E0118 19:18:38.546938       1 base_controller.go:270] "addon-deploy-controller" controller failed to sync "nweather-managed/managed-serviceaccount", err: manifestworks.work.open-cluster-management.io "addon-managed-serviceaccount-deploy" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
E0118 19:18:39.723862       1 base_controller.go:270] "addon-registration-controller" controller failed to sync "nweather-managed/managed-serviceaccount", err: roles.rbac.authorization.k8s.io "managed-serviceaccount-addon-agent" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
E0118 19:27:43.658618       1 base_controller.go:270] "cluster-management-addon-controller" controller failed to sync "local-cluster/managed-serviceaccount", err: managedclusteraddons.addon.open-cluster-management.io "managed-serviceaccount" is forbidden: cannot set an ownerRef on a resource you can't delete: , <nil>
E0118 19:27:43.671750       1 base_controller.go:270] "cluster-management-addon-controller" controller failed to sync "nweather-managed/managed-serviceaccount", err: managedclusteraddons.addon.open-cluster-management.io "managed-serviceaccount" is forbidden: cannot set an ownerRef on a resource you can't delete: , <nil>
E0118 19:27:43.680431       1 base_controller.go:270] "cluster-management-addon-controller" controller failed to sync "local-cluster/managed-serviceaccount", err: managedclusteraddons.addon.open-cluster-management.io "managed-serviceaccount" is forbidden: cannot set an ownerRef on a resource you can't delete: , <nil>
I0118 19:27:43.692118       1 event.go:282] Event(v1.ObjectReference{Kind:"Namespace", Namespace:"open-cluster-management-addon", Name:"open-cluster-management-addon", UID:"", APIVersion:"v1", ResourceVersion:"", FieldPath:""}): type: 'Warning' reason: 'ManifestWorkCreateFailed' Failed to create ManifestWork nweather-managed/addon-managed-serviceaccount-deploy: manifestworks.work.open-cluster-management.io "addon-managed-serviceaccount-deploy" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
E0118 19:27:43.703807       1 base_controller.go:270] "addon-deploy-controller" controller failed to sync "nweather-managed/managed-serviceaccount", err: manifestworks.work.open-cluster-management.io "addon-managed-serviceaccount-deploy" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
I0118 19:27:43.708354       1 event.go:282] Event(v1.ObjectReference{Kind:"Namespace", Namespace:"open-cluster-management-addon", Name:"open-cluster-management-addon", UID:"", APIVersion:"v1", ResourceVersion:"", FieldPath:""}): type: 'Warning' reason: 'ManifestWorkCreateFailed' Failed to create ManifestWork local-cluster/addon-managed-serviceaccount-deploy: manifestworks.work.open-cluster-management.io "addon-managed-serviceaccount-deploy" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
E0118 19:27:43.718043       1 base_controller.go:270] "addon-deploy-controller" controller failed to sync "local-cluster/managed-serviceaccount", err: manifestworks.work.open-cluster-management.io "addon-managed-serviceaccount-deploy" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
E0118 19:27:43.740259       1 base_controller.go:270] "addon-registration-controller" controller failed to sync "nweather-managed/managed-serviceaccount", err: roles.rbac.authorization.k8s.io "managed-serviceaccount-addon-agent" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
E0118 19:27:43.806804       1 base_controller.go:270] "addon-registration-controller" controller failed to sync "local-cluster/managed-serviceaccount", err: roles.rbac.authorization.k8s.io "managed-serviceaccount-addon-agent" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
E0118 19:34:38.709952       1 base_controller.go:270] "cluster-management-addon-controller" controller failed to sync "local-cluster/managed-serviceaccount", err: managedclusteraddons.addon.open-cluster-management.io "managed-serviceaccount" is forbidden: cannot set an ownerRef on a resource you can't delete: , <nil>
I0118 19:34:39.519631       1 event.go:282] Event(v1.ObjectReference{Kind:"Namespace", Namespace:"open-cluster-management-addon", Name:"open-cluster-management-addon", UID:"", APIVersion:"v1", ResourceVersion:"", FieldPath:""}): type: 'Warning' reason: 'ManifestWorkCreateFailed' Failed to create ManifestWork local-cluster/addon-managed-serviceaccount-deploy: manifestworks.work.open-cluster-management.io "addon-managed-serviceaccount-deploy" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
E0118 19:34:39.530712       1 base_controller.go:270] "addon-deploy-controller" controller failed to sync "local-cluster/managed-serviceaccount", err: manifestworks.work.open-cluster-management.io "addon-managed-serviceaccount-deploy" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
E0118 19:34:41.348703       1 base_controller.go:270] "addon-registration-controller" controller failed to sync "local-cluster/managed-serviceaccount", err: roles.rbac.authorization.k8s.io "managed-serviceaccount-addon-agent" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
E0118 19:35:17.138011       1 base_controller.go:270] "cluster-management-addon-controller" controller failed to sync "nweather-managed/managed-serviceaccount", err: managedclusteraddons.addon.open-cluster-management.io "managed-serviceaccount" is forbidden: cannot set an ownerRef on a resource you can't delete: , <nil>
I0118 19:35:18.581676       1 event.go:282] Event(v1.ObjectReference{Kind:"Namespace", Namespace:"open-cluster-management-addon", Name:"open-cluster-management-addon", UID:"", APIVersion:"v1", ResourceVersion:"", FieldPath:""}): type: 'Warning' reason: 'ManifestWorkCreateFailed' Failed to create ManifestWork nweather-managed/addon-managed-serviceaccount-deploy: manifestworks.work.open-cluster-management.io "addon-managed-serviceaccount-deploy" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
E0118 19:35:18.591347       1 base_controller.go:270] "addon-deploy-controller" controller failed to sync "nweather-managed/managed-serviceaccount", err: manifestworks.work.open-cluster-management.io "addon-managed-serviceaccount-deploy" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
E0118 19:35:19.824732       1 base_controller.go:270] "addon-registration-controller" controller failed to sync "nweather-managed/managed-serviceaccount", err: roles.rbac.authorization.k8s.io "managed-serviceaccount-addon-agent" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
E0118 19:37:43.661059       1 base_controller.go:270] "cluster-management-addon-controller" controller failed to sync "local-cluster/managed-serviceaccount", err: managedclusteraddons.addon.open-cluster-management.io "managed-serviceaccount" is forbidden: cannot set an ownerRef on a resource you can't delete: , <nil>
E0118 19:37:43.682400       1 base_controller.go:270] "cluster-management-addon-controller" controller failed to sync "nweather-managed/managed-serviceaccount", err: managedclusteraddons.addon.open-cluster-management.io "managed-serviceaccount" is forbidden: cannot set an ownerRef on a resource you can't delete: , <nil>
I0118 19:37:43.688259       1 event.go:282] Event(v1.ObjectReference{Kind:"Namespace", Namespace:"open-cluster-management-addon", Name:"open-cluster-management-addon", UID:"", APIVersion:"v1", ResourceVersion:"", FieldPath:""}): type: 'Warning' reason: 'ManifestWorkCreateFailed' Failed to create ManifestWork nweather-managed/addon-managed-serviceaccount-deploy: manifestworks.work.open-cluster-management.io "addon-managed-serviceaccount-deploy" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
E0118 19:37:43.692805       1 base_controller.go:270] "cluster-management-addon-controller" controller failed to sync "local-cluster/managed-serviceaccount", err: managedclusteraddons.addon.open-cluster-management.io "managed-serviceaccount" is forbidden: cannot set an ownerRef on a resource you can't delete: , <nil>
E0118 19:37:43.695545       1 base_controller.go:270] "addon-deploy-controller" controller failed to sync "nweather-managed/managed-serviceaccount", err: manifestworks.work.open-cluster-management.io "addon-managed-serviceaccount-deploy" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
I0118 19:37:43.699276       1 event.go:282] Event(v1.ObjectReference{Kind:"Namespace", Namespace:"open-cluster-management-addon", Name:"open-cluster-management-addon", UID:"", APIVersion:"v1", ResourceVersion:"", FieldPath:""}): type: 'Warning' reason: 'ManifestWorkCreateFailed' Failed to create ManifestWork local-cluster/addon-managed-serviceaccount-deploy: manifestworks.work.open-cluster-management.io "addon-managed-serviceaccount-deploy" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
E0118 19:37:43.709112       1 base_controller.go:270] "addon-deploy-controller" controller failed to sync "local-cluster/managed-serviceaccount", err: manifestworks.work.open-cluster-management.io "addon-managed-serviceaccount-deploy" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
E0118 19:37:43.738622       1 base_controller.go:270] "addon-registration-controller" controller failed to sync "nweather-managed/managed-serviceaccount", err: roles.rbac.authorization.k8s.io "managed-serviceaccount-addon-agent" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
E0118 19:37:43.829838       1 base_controller.go:270] "addon-registration-controller" controller failed to sync "local-cluster/managed-serviceaccount", err: roles.rbac.authorization.k8s.io "managed-serviceaccount-addon-agent" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
E0118 19:47:43.676208       1 base_controller.go:270] "cluster-management-addon-controller" controller failed to sync "local-cluster/managed-serviceaccount", err: managedclusteraddons.addon.open-cluster-management.io "managed-serviceaccount" is forbidden: cannot set an ownerRef on a resource you can't delete: , <nil>
E0118 19:47:43.690484       1 base_controller.go:270] "cluster-management-addon-controller" controller failed to sync "nweather-managed/managed-serviceaccount", err: managedclusteraddons.addon.open-cluster-management.io "managed-serviceaccount" is forbidden: cannot set an ownerRef on a resource you can't delete: , <nil>
E0118 19:47:43.696689       1 base_controller.go:270] "cluster-management-addon-controller" controller failed to sync "local-cluster/managed-serviceaccount", err: managedclusteraddons.addon.open-cluster-management.io "managed-serviceaccount" is forbidden: cannot set an ownerRef on a resource you can't delete: , <nil>
I0118 19:47:43.705275       1 event.go:282] Event(v1.ObjectReference{Kind:"Namespace", Namespace:"open-cluster-management-addon", Name:"open-cluster-management-addon", UID:"", APIVersion:"v1", ResourceVersion:"", FieldPath:""}): type: 'Warning' reason: 'ManifestWorkCreateFailed' Failed to create ManifestWork nweather-managed/addon-managed-serviceaccount-deploy: manifestworks.work.open-cluster-management.io "addon-managed-serviceaccount-deploy" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
E0118 19:47:43.712417       1 base_controller.go:270] "addon-deploy-controller" controller failed to sync "nweather-managed/managed-serviceaccount", err: manifestworks.work.open-cluster-management.io "addon-managed-serviceaccount-deploy" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
I0118 19:47:43.717490       1 event.go:282] Event(v1.ObjectReference{Kind:"Namespace", Namespace:"open-cluster-management-addon", Name:"open-cluster-management-addon", UID:"", APIVersion:"v1", ResourceVersion:"", FieldPath:""}): type: 'Warning' reason: 'ManifestWorkCreateFailed' Failed to create ManifestWork local-cluster/addon-managed-serviceaccount-deploy: manifestworks.work.open-cluster-management.io "addon-managed-serviceaccount-deploy" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
E0118 19:47:43.726571       1 base_controller.go:270] "addon-deploy-controller" controller failed to sync "local-cluster/managed-serviceaccount", err: manifestworks.work.open-cluster-management.io "addon-managed-serviceaccount-deploy" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
E0118 19:47:43.748463       1 base_controller.go:270] "addon-registration-controller" controller failed to sync "nweather-managed/managed-serviceaccount", err: roles.rbac.authorization.k8s.io "managed-serviceaccount-addon-agent" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
E0118 19:47:43.810994       1 base_controller.go:270] "addon-registration-controller" controller failed to sync "local-cluster/managed-serviceaccount", err: roles.rbac.authorization.k8s.io "managed-serviceaccount-addon-agent" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
E0118 19:51:18.717228       1 base_controller.go:270] "cluster-management-addon-controller" controller failed to sync "local-cluster/managed-serviceaccount", err: managedclusteraddons.addon.open-cluster-management.io "managed-serviceaccount" is forbidden: cannot set an ownerRef on a resource you can't delete: , <nil>
I0118 19:51:19.577546       1 event.go:282] Event(v1.ObjectReference{Kind:"Namespace", Namespace:"open-cluster-management-addon", Name:"open-cluster-management-addon", UID:"", APIVersion:"v1", ResourceVersion:"", FieldPath:""}): type: 'Warning' reason: 'ManifestWorkCreateFailed' Failed to create ManifestWork local-cluster/addon-managed-serviceaccount-deploy: manifestworks.work.open-cluster-management.io "addon-managed-serviceaccount-deploy" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
E0118 19:51:19.590568       1 base_controller.go:270] "addon-deploy-controller" controller failed to sync "local-cluster/managed-serviceaccount", err: manifestworks.work.open-cluster-management.io "addon-managed-serviceaccount-deploy" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
E0118 19:51:21.416440       1 base_controller.go:270] "addon-registration-controller" controller failed to sync "local-cluster/managed-serviceaccount", err: roles.rbac.authorization.k8s.io "managed-serviceaccount-addon-agent" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
E0118 19:51:57.159025       1 base_controller.go:270] "cluster-management-addon-controller" controller failed to sync "nweather-managed/managed-serviceaccount", err: managedclusteraddons.addon.open-cluster-management.io "managed-serviceaccount" is forbidden: cannot set an ownerRef on a resource you can't delete: , <nil>
I0118 19:51:58.629081       1 event.go:282] Event(v1.ObjectReference{Kind:"Namespace", Namespace:"open-cluster-management-addon", Name:"open-cluster-management-addon", UID:"", APIVersion:"v1", ResourceVersion:"", FieldPath:""}): type: 'Warning' reason: 'ManifestWorkCreateFailed' Failed to create ManifestWork nweather-managed/addon-managed-serviceaccount-deploy: manifestworks.work.open-cluster-management.io "addon-managed-serviceaccount-deploy" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
E0118 19:51:58.639054       1 base_controller.go:270] "addon-deploy-controller" controller failed to sync "nweather-managed/managed-serviceaccount", err: manifestworks.work.open-cluster-management.io "addon-managed-serviceaccount-deploy" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
E0118 19:51:59.891154       1 base_controller.go:270] "addon-registration-controller" controller failed to sync "nweather-managed/managed-serviceaccount", err: roles.rbac.authorization.k8s.io "managed-serviceaccount-addon-agent" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
E0118 19:57:43.675917       1 base_controller.go:270] "cluster-management-addon-controller" controller failed to sync "local-cluster/managed-serviceaccount", err: managedclusteraddons.addon.open-cluster-management.io "managed-serviceaccount" is forbidden: cannot set an ownerRef on a resource you can't delete: , <nil>
# Please edit the object below. Lines beginning with a '#' will be ignored,
E0118 19:57:43.685575       1 base_controller.go:270] "cluster-management-addon-controller" controller failed to sync "nweather-managed/managed-serviceaccount", err: managedclusteraddons.addon.open-cluster-management.io "managed-serviceaccount" is forbidden: cannot set an ownerRef on a resource you can't delete: , <nil>
I0118 19:57:43.690272       1 event.go:282] Event(v1.ObjectReference{Kind:"Namespace", Namespace:"open-cluster-management-addon", Name:"open-cluster-management-addon", UID:"", APIVersion:"v1", ResourceVersion:"", FieldPath:""}): type: 'Warning' reason: 'ManifestWorkCreateFailed' Failed to create ManifestWork nweather-managed/addon-managed-serviceaccount-deploy: manifestworks.work.open-cluster-management.io "addon-managed-serviceaccount-deploy" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
E0118 19:57:43.694018       1 base_controller.go:270] "cluster-management-addon-controller" controller failed to sync "local-cluster/managed-serviceaccount", err: managedclusteraddons.addon.open-cluster-management.io "managed-serviceaccount" is forbidden: cannot set an ownerRef on a resource you can't delete: , <nil>
E0118 19:57:43.697214       1 base_controller.go:270] "addon-deploy-controller" controller failed to sync "nweather-managed/managed-serviceaccount", err: manifestworks.work.open-cluster-management.io "addon-managed-serviceaccount-deploy" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
I0118 19:57:43.701541       1 event.go:282] Event(v1.ObjectReference{Kind:"Namespace", Namespace:"open-cluster-management-addon", Name:"open-cluster-management-addon", UID:"", APIVersion:"v1", ResourceVersion:"", FieldPath:""}): type: 'Warning' reason: 'ManifestWorkCreateFailed' Failed to create ManifestWork local-cluster/addon-managed-serviceaccount-deploy: manifestworks.work.open-cluster-management.io "addon-managed-serviceaccount-deploy" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
E0118 19:57:43.708736       1 base_controller.go:270] "addon-deploy-controller" controller failed to sync "local-cluster/managed-serviceaccount", err: manifestworks.work.open-cluster-management.io "addon-managed-serviceaccount-deploy" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
E0118 19:57:43.736940       1 base_controller.go:270] "addon-registration-controller" controller failed to sync "nweather-managed/managed-serviceaccount", err: roles.rbac.authorization.k8s.io "managed-serviceaccount-addon-agent" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
E0118 19:57:43.804672       1 base_controller.go:270] "addon-registration-controller" controller failed to sync "local-cluster/managed-serviceaccount", err: roles.rbac.authorization.k8s.io "managed-serviceaccount-addon-agent" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
```
</details>

Summarizing: 

```
message: 'failed to apply manifestwork: manifestworks.work.open-cluster-management.io\n        \"addon-managed-serviceaccount-deploy\" is forbidden: cannot set blockOwnerDeletion\n        if an ownerReference refers to a resource you can''t set finalizers on: , <nil>'
```

Adding the `- managedclusteraddons/finalizers` line to the clusterrole.yaml fixes this error