### PR TITLE
provide option to configure agent install strategy

### DIFF
--- a/charts/managed-serviceaccount/templates/manager-deployment.yaml
+++ b/charts/managed-serviceaccount/templates/manager-deployment.yaml
@@ -16,9 +16,10 @@ spec:
       serviceAccount: managed-serviceaccount
       containers:
         - name: manager
-          image: {{ .Values.image }}:{{ .Values.tag }}
+          image: "{{ .Values.image }}:{{ .Values.tag }}"
           command:
             - /manager
           args:
             - --leader-elect=true
             - --agent-image-name={{ .Values.image }}:{{ .Values.tag }}
+            - --agent-install-all={{ .Values.agentInstallAll }}

--- a/charts/managed-serviceaccount/values.yaml
+++ b/charts/managed-serviceaccount/values.yaml
@@ -1,7 +1,7 @@
 # Image of the managed service-account instances
 image: quay.io/open-cluster-management/managed-serviceaccount
-
 tag: v0.1.0
+agentInstallAll: true
 
 # Number of replicas
 replicas: 1

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -55,6 +55,8 @@ func main() {
 	var enableLeaderElection bool
 	var probeAddr string
 	var addonAgentImageName string
+	var agentInstallAll bool
+
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":38080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":38081", "The address the probe endpoint binds to.")
 	flag.StringVar(&addonAgentImageName, "agent-image-name", "yue9944882/managed-serviceaccount-addon-agent:v0.0.0",
@@ -62,6 +64,11 @@ func main() {
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
+	flag.BoolVar(
+		&agentInstallAll, "agent-install-all", false,
+		"Configure the install strategy of agent on managed clusters. "+
+			"Enabling this will automatically install agent on all managed cluster.")
+
 	opts := zap.Options{
 		Development: true,
 	}
@@ -95,7 +102,14 @@ func main() {
 		os.Exit(1)
 	}
 
-	err = addonManager.AddAgent(manager.NewManagedServiceAccountAddonAgent(nativeClient, addonAgentImageName))
+	err = addonManager.AddAgent(
+		manager.NewManagedServiceAccountAddonAgent(
+			nativeClient,
+			addonAgentImageName,
+			agentInstallAll,
+		),
+	)
+
 	if err != nil {
 		setupLog.Error(err, "unable to register addon agent")
 		os.Exit(1)


### PR DESCRIPTION
previous strategy enable managed-serviceaccount addon on all managedclusters, user is not able to disable the addon by removing the ManagedClusterAddon resource

the proposed change add a new option `agent-install-all` to the binary 

if `agent-install-all == true`  enable agent on all managed clusters
if `agent-install-all == false` do not enable agent by default and  the addon will only be enabled when a ManagedClusterAddon is created in the cluster namespace and will be disabled when the ManagedClusterAddon is deleted

example ManagedClusterAddon
```
apiVersion: addon.open-cluster-management.io/v1alpha1
kind: ManagedClusterAddOn
metadata:
  name: managed-serviceaccount
  namespace: hao-aks
spec:
  installNamespace: open-cluster-management-managed-serviceaccount
```