### PR TITLE
adding delete for managedserviceaccounts

### DIFF
--- a/charts/managed-serviceaccount/templates/clusterrole.yaml
+++ b/charts/managed-serviceaccount/templates/clusterrole.yaml
@@ -37,6 +37,9 @@ rules:
       - watch
       - update
       - patch
+      {{- if (.Values.featureGates | default dict).ephemeralIdentity }}
+      - delete
+      {{- end }}
   - apiGroups:
       - certificates.k8s.io
     resources:


### PR DESCRIPTION
Signed-off-by: Hanqiu Zhang <hanzhang@redhat.com>

Updates
- added delete managedserviceaccounts permission when `ephemeralIdentity` is enabled.