### PR TITLE
Remove eventbroadcaster

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -16,7 +16,6 @@ import (
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
-	"k8s.io/client-go/tools/record"
 	"k8s.io/klog/v2"
 	"k8s.io/klog/v2/klogr"
 	addonutils "open-cluster-management.io/addon-framework/pkg/utils"
@@ -89,7 +88,6 @@ func main() {
 		LeaderElection:         enableLeaderElection,
 		LeaderElectionID:       "managed-serviceaccount-addon-agent",
 		LeaderElectionConfig:   spokeCfg,
-		EventBroadcaster:       record.NewBroadcaster(),
 	})
 	if err != nil {
 		klog.Fatal("unable to start manager")


### PR DESCRIPTION
There are 2 reasons to remove boardcast:
1. we don't have event permission set in agent manifest
2. `EventBroadcaster` is Deprecated because `using this may cause goroutine leaks if the lifetime of your manager or controllers`