### PR TITLE
Remove securityContext log errors in OCP 4.11+

### DIFF
--- a/charts/managed-serviceaccount/templates/manager-deployment.yaml
+++ b/charts/managed-serviceaccount/templates/manager-deployment.yaml
@@ -14,6 +14,11 @@ spec:
         open-cluster-management.io/addon: managed-serviceaccount
     spec:
       serviceAccount: managed-serviceaccount
+      securityContext:
+        {{- if semverCompare ">=4.11.0" .Values.hubconfig.ocpVersion }} 
+        seccompProfile: 
+          type: RuntimeDefault
+        {{- end }}
       containers:
         - name: manager
           image: {{ .Values.image }}:{{ .Values.tag | default (print "v" .Chart.Version) }}


### PR DESCRIPTION
ACM Installer team is cleaning up our logs and ran into KupeAPIWarnings that the seccompProfile needs to be set to RuntimeDefault for our operands. Please add this conditional in the deployment yaml to fix the error.

issue: https://issues.redhat.com/browse/ACM-3072

Signed-off-by: Erin Murphy erinmurp@redhat.com