### PR TITLE
:seedling: Use serviceAccountName instead of deprecated serviceAccount

### DIFF
--- a/pkg/addon/manager/manifests/templates/deployment.yaml
+++ b/pkg/addon/manager/manifests/templates/deployment.yaml
@@ -13,7 +13,7 @@ spec:
       labels:
         addon-agent: managed-serviceaccount
     spec:
-      serviceAccount: managed-serviceaccount
+      serviceAccountName: managed-serviceaccount
 {{- if .NodeSelector }}
       nodeSelector:
       {{- range $key, $value := .NodeSelector }}


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:rocket: 🚀 release
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

## Related issue(s)

Fixes #
