### PR TITLE
:bug: do not create lease if deploy using addontemplate

### DIFF
--- a/pkg/addon/manager/manifests/templates/deployment.yaml
+++ b/pkg/addon/manager/manifests/templates/deployment.yaml
@@ -42,6 +42,7 @@ spec:
             - --leader-elect=false
             - --cluster-name={{ .ClusterName }}
             - --kubeconfig=/etc/hub/kubeconfig
+            - --lease-health-check=true
           volumeMounts:
             - name: hub-kubeconfig
               mountPath: /etc/hub/


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:rocket: 🚀 release
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

if the addon is deployed using addontemplate, do not need to create lease to do health check.
if the addon is deployed using hub manager, need to create lease to do health check. 

## Related issue(s)

Fixes #
