### PR TITLE
🌱 CI should pass when on codecov upload fail

### DIFF
--- a/.github/workflows/go-presubmit.yml
+++ b/.github/workflows/go-presubmit.yml
@@ -49,7 +49,7 @@ jobs:
           flags: unit
           name: unit
           verbose: true
-          fail_ci_if_error: true
+          fail_ci_if_error: false
 
   integration:
     name: integration


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:rocket: 🚀 release
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

Recently, Codecov has become unstable. There is a high probability that it will fail since the results cannot be uploaded. so this PR changes to pass CI job when the codecov upload is failed. when it is stable we will change this back.

```
[2024-04-17T18:26:30.436Z] ['verbose'] The error stack is: Error: Error uploading to [https://codecov.io:](https://codecov.io/) Error: There was an error fetching the storage URL during POST: 404 - {'detail': ErrorDetail(string='Unable to locate build via Github Actions API. Please upload with the Codecov repository upload token to resolve issue.', code='not_found')}
```

## Related issue(s)

https://github.com/codecov/codecov-action/issues/926
https://github.com/open-cluster-management-io/ocm/pull/396

Fixes #https://github.com/open-cluster-management-io/managed-serviceaccount/actions/runs/8731709928/job/23957554124?pr=104
