### PR TITLE
🐛 Remove the enableAddOnDeploymentConfig value

### DIFF
--- a/.github/workflows/go-presubmit.yml
+++ b/.github/workflows/go-presubmit.yml
@@ -94,8 +94,7 @@ jobs:
              -n open-cluster-management-addon --create-namespace \
              managed-serviceaccount charts/managed-serviceaccount/ \
              --set tag=latest \
-             --set featureGates.ephemeralIdentity=true \
-             --set enableAddOnDeploymentConfig=true
+             --set featureGates.ephemeralIdentity=true
       - name: Run e2e test
         run: make test-e2e GENKGO_ARGS='--ginkgo.label-filter='\''!template-install'\'''
 
@@ -133,7 +132,6 @@ jobs:
             managed-serviceaccount charts/managed-serviceaccount/ \
             --set tag=latest \
             --set featureGates.ephemeralIdentity=true \
-            --set enableAddOnDeploymentConfig=true \
             --set hubDeployMode=AddOnTemplate \
             --set targetCluster=loopback
       - name: Run e2e test

--- a/charts/managed-serviceaccount/templates/clustermanagementaddon.yaml
+++ b/charts/managed-serviceaccount/templates/clustermanagementaddon.yaml
@@ -10,13 +10,9 @@ spec:
   addOnMeta:
     displayName: managed-serviceaccount
     description: managed-serviceaccount
-{{- if or (.Values.enableAddOnDeploymentConfig) (eq .Values.hubDeployMode "AddOnTemplate") }}
   supportedConfigs:
-{{- end }}
-{{- if .Values.enableAddOnDeploymentConfig }}
   - group: addon.open-cluster-management.io
     resource: addondeploymentconfigs
-{{- end }}
 {{- if eq .Values.hubDeployMode "AddOnTemplate" }}
   - group: addon.open-cluster-management.io
     resource: addontemplates

--- a/charts/managed-serviceaccount/templates/clustermanagementaddon.yaml
+++ b/charts/managed-serviceaccount/templates/clustermanagementaddon.yaml
@@ -10,8 +10,10 @@ spec:
   addOnMeta:
     displayName: managed-serviceaccount
     description: managed-serviceaccount
-{{- if .Values.enableAddOnDeploymentConfig }}
+{{- if or (.Values.enableAddOnDeploymentConfig) (eq .Values.hubDeployMode "AddOnTemplate") }}
   supportedConfigs:
+{{- end }}
+{{- if .Values.enableAddOnDeploymentConfig }}
   - group: addon.open-cluster-management.io
     resource: addondeploymentconfigs
 {{- end }}

--- a/charts/managed-serviceaccount/values.yaml
+++ b/charts/managed-serviceaccount/values.yaml
@@ -6,8 +6,6 @@ agentInstallAll: true
 # Number of replicas
 replicas: 1
 
-enableAddOnDeploymentConfig: false
-
 featureGates:
   ephemeralIdentity: false
 


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:rocket: 🚀 release
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

Remove the enableAddOnDeploymentConfig value to fix helm template error when enableAddOnDeploymentConfig is false, but hubDeployMode is AddOnTemplate. the addonDeploymentConfig should always be enabled.

```
╰─# helm template charts/managed-serviceaccount
Error: YAML parse error on managed-serviceaccount/templates/clustermanagementaddon.yaml: error converting YAML to JSON: yaml: line 10: did not find expected key

Use --debug flag to render out invalid YAML
```

## Related issue(s)

Fixes #
