### PR TITLE
🐛 Only delele serviceaccount managed by the addon agent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,8 @@ else
 GOBIN=$(shell go env GOBIN)
 endif
 
-export CGO_ENABLED  = 1
+export DOCKER_BUILDER ?= docker
+export CGO_ENABLED = 1
 export GOFLAGS ?=
 
 # Setting SHELL to bash allows bash commands to be executed by recipes.
@@ -113,7 +114,10 @@ rm -rf $$TMP_DIR ;\
 endef
 
 images:
-	docker build -t ${IMG_REGISTRY}/managed-serviceaccount:${IMAGE_TAG} -f Dockerfile .
+	$(DOCKER_BUILDER) build -t ${IMG_REGISTRY}/managed-serviceaccount:${IMAGE_TAG} -f Dockerfile .
+
+images-amd64:
+	$(DOCKER_BUILDER) build --platform linux/amd64 -t ${IMG_REGISTRY}/managed-serviceaccount:${IMAGE_TAG} -f Dockerfile .
 
 test-integration:
 	@echo "TODO: Run integration test"

--- a/pkg/addon/agent/controller/token.go
+++ b/pkg/addon/agent/controller/token.go
@@ -75,15 +75,33 @@ func (r *TokenReconciler) Reconcile(ctx context.Context, request reconcile.Reque
 			return reconcile.Result{}, errors.Wrapf(err, "fail to get managed serviceaccount")
 		}
 
-		sai := r.SpokeNativeClient.CoreV1().ServiceAccounts(r.SpokeNamespace)
-		if err := sai.Delete(ctx, request.Name, metav1.DeleteOptions{}); err != nil {
+		saclient := r.SpokeNativeClient.CoreV1().ServiceAccounts(r.SpokeNamespace)
+		sa, err := saclient.Get(ctx, request.Name, metav1.GetOptions{})
+		if err != nil {
+			if !apierrors.IsNotFound(err) {
+				// fail to get related serviceaccount, requeue
+				return reconcile.Result{}, errors.Wrapf(err, "fail to get related serviceaccount")
+			}
+
+			logger.Info("Both ManagedServiceAccount and related ServiceAccount does not exist")
+			return reconcile.Result{}, nil
+		}
+
+		// check if the serviceacount is managed by the agent, if not, return
+		if sa.Labels[common.LabelKeyIsManagedServiceAccount] != "true" {
+
+			logger.Info("Related ServiceAccount is not managed by the agent, skip deletion")
+			return reconcile.Result{}, nil
+		}
+
+		if err := saclient.Delete(ctx, request.Name, metav1.DeleteOptions{}); err != nil {
 			if !apierrors.IsNotFound(err) {
 				// fail to delete related serviceaccount, requeue
 				return reconcile.Result{}, errors.Wrapf(err, "fail to delete related serviceaccount")
 			}
 		}
 
-		logger.Info("Both ManagedServiceAccount and related ServiceAccount does not exist")
+		logger.Info("Delete related ServiceAccount successfully")
 		return reconcile.Result{}, nil
 	}
 


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:rocket: 🚀 release
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

When delete a managedserviceaccount, only delele the serviceaccount that is created by the addon agent

## Related issue(s)

Fixes #
