### PR TITLE
:seedling: Update dependencies by group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,29 @@ updates:
   commit-message:
       prefix: ":seedling:"
   open-pull-requests-limit: 3
+  groups:
+    k8s.io:
+      patterns:
+        - "k8s.io/*"
+        - "sigs.k8s.io/*"
+    go.opentelemetry.io:
+      patterns:
+        - "go.opentelemetry.io/*"
+    open-cluster-management.io:
+      patterns:
+        - "open-cluster-management.io/*"
+    prometheus:
+      patterns:
+        - "github.com/prometheus/*"
+    google:
+      patterns:
+        - "github.com/google/*"
+    spf13:
+      patterns:
+        - "github.com/spf13/*"
+    testing:
+      patterns:
+        - "github.com/onsi/*"
 - package-ecosystem: "github-actions"
   directory: "/"
   schedule:


### PR DESCRIPTION
## Summary
- Add dependency groups to dependabot configuration to organize Go module updates by import path prefixes
- Groups include k8s.io, opentelemetry, OCM, prometheus, google, spf13, and testing packages
- Follows the same approach as implemented in open-cluster-management-io/ocm#1088

## Test plan
- [x] Verify dependabot.yml syntax is valid
- [ ] Monitor that dependabot creates grouped PRs instead of individual ones
- [ ] Confirm updates are properly categorized by dependency group

🤖 Generated with [Claude Code](https://claude.ai/code)