### PR TITLE
:bug: Incorrect rolebinding for spoke with token addon registration

### DIFF
--- a/pkg/addon/manager/addon.go
+++ b/pkg/addon/manager/addon.go
@@ -5,8 +5,10 @@ import (
 	"embed"
 	"encoding/base64"
 
+	certificatesv1 "k8s.io/api/certificates/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -17,6 +19,12 @@ import (
 	addonv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
 	"open-cluster-management.io/managed-serviceaccount/pkg/common"
+)
+
+// Kube client registration driver values (ManagedClusterAddOn.status.kubeClientDriver).
+const (
+	TokenDriver = "token"
+	CSRDriver   = "csr"
 )
 
 //go:embed manifests/templates
@@ -52,7 +60,22 @@ func NewRegistrationOption(nativeClient kubernetes.Interface) *agent.Registratio
 func setupPermission(nativeClient kubernetes.Interface) agent.PermissionConfigFunc {
 	return func(cluster *clusterv1.ManagedCluster, addon *addonv1alpha1.ManagedClusterAddOn) error {
 		namespace := cluster.Name
-		agentUser := "system:open-cluster-management:cluster:" + cluster.Name + ":addon:managed-serviceaccount:agent:addon-agent"
+
+		var subjects []rbacv1.Subject
+		if addon.Status.KubeClientDriver == TokenDriver {
+			subjects = rbacSubjectsFromKubeClientRegistration(addon)
+			if len(subjects) == 0 {
+				return &agent.SubjectNotReadyError{}
+			}
+		} else {
+			subjects = []rbacv1.Subject{
+				{
+					Kind: rbacv1.UserKind,
+					Name: agent.DefaultUser(cluster.Name, common.AddonName, common.AgentName),
+				},
+			}
+		}
+
 		role := &rbacv1.Role{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "managed-serviceaccount-addon-agent",
@@ -103,12 +126,7 @@ func setupPermission(nativeClient kubernetes.Interface) agent.PermissionConfigFu
 				Kind: "Role",
 				Name: "managed-serviceaccount-addon-agent",
 			},
-			Subjects: []rbacv1.Subject{
-				{
-					Kind: rbacv1.UserKind,
-					Name: agentUser,
-				},
-			},
+			Subjects: subjects,
 		}
 
 		if _, err := nativeClient.RbacV1().Roles(namespace).Create(
@@ -129,4 +147,40 @@ func setupPermission(nativeClient kubernetes.Interface) agent.PermissionConfigFu
 		}
 		return nil
 	}
+}
+
+// rbacSubjectsFromKubeClientRegistration mirrors addon-framework registration subject handling for
+// kubernetes.io/kube-apiserver-client: use the user and groups published in ManagedClusterAddOn status
+// (required for klusterlet token registration). The system:authenticated group is omitted so bindings stay narrow.
+func rbacSubjectsFromKubeClientRegistration(addon *addonv1alpha1.ManagedClusterAddOn) []rbacv1.Subject {
+	var subject *addonv1alpha1.Subject
+	for i := range addon.Status.Registrations {
+		if addon.Status.Registrations[i].SignerName == certificatesv1.KubeAPIServerClientSignerName {
+			subject = &addon.Status.Registrations[i].Subject
+			break
+		}
+	}
+	if subject == nil || equality.Semantic.DeepEqual(*subject, addonv1alpha1.Subject{}) {
+		return nil
+	}
+
+	var subjects []rbacv1.Subject
+	if subject.User != "" {
+		subjects = append(subjects, rbacv1.Subject{
+			Kind:     rbacv1.UserKind,
+			APIGroup: rbacv1.GroupName,
+			Name:     subject.User,
+		})
+	}
+	for _, group := range subject.Groups {
+		if group == "system:authenticated" {
+			continue
+		}
+		subjects = append(subjects, rbacv1.Subject{
+			Kind:     rbacv1.GroupKind,
+			APIGroup: rbacv1.GroupName,
+			Name:     group,
+		})
+	}
+	return subjects
 }

--- a/pkg/addon/manager/addon_test.go
+++ b/pkg/addon/manager/addon_test.go
@@ -1,15 +1,18 @@
 package manager
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	certificatesv1 "k8s.io/api/certificates/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	fakekube "k8s.io/client-go/kubernetes/fake"
 	clienttesting "k8s.io/client-go/testing"
 	"open-cluster-management.io/addon-framework/pkg/addonfactory"
+	"open-cluster-management.io/addon-framework/pkg/agent"
 	addonv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
 	"open-cluster-management.io/managed-serviceaccount/pkg/common"
@@ -33,6 +36,119 @@ func TestNewRegistrationOption(t *testing.T) {
 	rolebinding := actions[1].(clienttesting.CreateAction).GetObject().(*rbacv1.RoleBinding)
 	assert.Equal(t, clusterName, rolebinding.Namespace, "invalid rolebinding ns")
 	assert.Equal(t, "managed-serviceaccount-addon-agent", rolebinding.Name, "invalid rolebinding name")
+}
+
+// TestSetupPermission_tokenDriver_bindsRegistrationSubject documents GitHub issue #279: with klusterlet token
+// registration, the hub RoleBinding must use the subject published in ManagedClusterAddOn status (the
+// system:serviceaccount:... identity), not the CSR-style OCM user.
+func TestSetupPermission_tokenDriver_bindsRegistrationSubject(t *testing.T) {
+	clusterName := "cluster1"
+	addonName := common.AddonName
+	expectedSubjectUser := "system:serviceaccount:" + clusterName + ":" + addonName + "-agent"
+
+	fakeKubeClient := fakekube.NewSimpleClientset()
+	permissionConfig := NewRegistrationOption(fakeKubeClient).PermissionConfig
+
+	addon := newTestAddOn(addonName, clusterName)
+	addon.Status.KubeClientDriver = TokenDriver
+	addon.Status.Registrations = []addonv1alpha1.RegistrationConfig{
+		{
+			SignerName: certificatesv1.KubeAPIServerClientSignerName,
+			Subject: addonv1alpha1.Subject{
+				User: expectedSubjectUser,
+			},
+		},
+	}
+
+	err := permissionConfig(newTestCluster(clusterName), addon)
+	assert.NoError(t, err)
+
+	var roleBinding *rbacv1.RoleBinding
+	for _, a := range fakeKubeClient.Actions() {
+		create, ok := a.(clienttesting.CreateAction)
+		if !ok {
+			continue
+		}
+		if rb, ok := create.GetObject().(*rbacv1.RoleBinding); ok {
+			roleBinding = rb
+			break
+		}
+	}
+	assert.NotNil(t, roleBinding, "expected a RoleBinding create action")
+	if roleBinding == nil {
+		return
+	}
+	assert.Len(t, roleBinding.Subjects, 1, "expected exactly one subject on RoleBinding")
+	assert.Equal(t, rbacv1.UserKind, roleBinding.Subjects[0].Kind)
+	assert.Equal(t, expectedSubjectUser, roleBinding.Subjects[0].Name,
+		"token registration must bind the hub kube client subject user, not the CSR registration user")
+}
+
+func TestSetupPermission_csrDriver_bindsDefaultUser(t *testing.T) {
+	clusterName := "cluster1"
+	fakeKubeClient := fakekube.NewSimpleClientset()
+	addon := newTestAddOn(common.AddonName, clusterName)
+	addon.Status.KubeClientDriver = CSRDriver
+
+	err := NewRegistrationOption(fakeKubeClient).PermissionConfig(newTestCluster(clusterName), addon)
+	assert.NoError(t, err)
+
+	var roleBinding *rbacv1.RoleBinding
+	for _, a := range fakeKubeClient.Actions() {
+		if c, ok := a.(clienttesting.CreateAction); ok {
+			if rb, ok := c.GetObject().(*rbacv1.RoleBinding); ok {
+				roleBinding = rb
+			}
+		}
+	}
+	assert.NotNil(t, roleBinding)
+	assert.Equal(t, agent.DefaultUser(clusterName, common.AddonName, common.AgentName), roleBinding.Subjects[0].Name)
+}
+
+// TestSetupPermission_tokenDriver_subjectNotReady verifies we wait until the spoke has published
+// registration subject before applying hub RBAC.
+func TestSetupPermission_tokenDriver_subjectNotReady(t *testing.T) {
+	clusterName := "cluster1"
+	addonName := common.AddonName
+
+	t.Run("no kube client registration entry", func(t *testing.T) {
+		fakeKubeClient := fakekube.NewSimpleClientset()
+		permissionConfig := NewRegistrationOption(fakeKubeClient).PermissionConfig
+		addon := newTestAddOn(addonName, clusterName)
+		addon.Status.KubeClientDriver = TokenDriver
+
+		err := permissionConfig(newTestCluster(clusterName), addon)
+		var subjectErr *agent.SubjectNotReadyError
+		assert.True(t, errors.As(err, &subjectErr), "expected SubjectNotReadyError while token subject is unset, got %v", err)
+		assertNoCreateActions(t, fakeKubeClient.Actions())
+	})
+
+	t.Run("kube client registration with empty subject", func(t *testing.T) {
+		fakeKubeClient := fakekube.NewSimpleClientset()
+		permissionConfig := NewRegistrationOption(fakeKubeClient).PermissionConfig
+		addon := newTestAddOn(addonName, clusterName)
+		addon.Status.KubeClientDriver = TokenDriver
+		addon.Status.Registrations = []addonv1alpha1.RegistrationConfig{
+			{
+				SignerName: certificatesv1.KubeAPIServerClientSignerName,
+				Subject:    addonv1alpha1.Subject{},
+			},
+		}
+
+		err := permissionConfig(newTestCluster(clusterName), addon)
+		var subjectErr *agent.SubjectNotReadyError
+		assert.True(t, errors.As(err, &subjectErr), "expected SubjectNotReadyError for empty registration subject, got %v", err)
+		assertNoCreateActions(t, fakeKubeClient.Actions())
+	})
+}
+
+func assertNoCreateActions(t *testing.T, actions []clienttesting.Action) {
+	t.Helper()
+	for _, a := range actions {
+		if _, ok := a.(clienttesting.CreateAction); ok {
+			t.Fatalf("expected no CreateAction writes, saw %#v", a)
+		}
+	}
 }
 
 func TestManifestAddonAgent(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes incorrect hub `RoleBinding` subjects for the managed-serviceaccount addon when managed clusters use **token**-based klusterlet addon registration (`spec.registrationConfiguration.addOnKubeClientRegistrationDriver.authType: token`). Hub RBAC must bind to the identity published in `ManagedClusterAddOn.status.registrations` (the `system:serviceaccount:<cluster-ns>:managed-serviceaccount-agent` user), not the CSR-style `system:open-cluster-management:cluster:...:agent:addon-agent` user.

### Problem

`setupPermission` always created the hub `RoleBinding` for a fixed CSR registration user. With token registration, the addon authenticates to the hub API as the service account user above; RBAC did not match that principal, leading to denied hub API calls and a broken or flaky addon on token-registered clusters.

### Solution

- If `ManagedClusterAddOn.status.kubeClientDriver == "token"`, derive `RoleBinding.subjects` from `status.registrations` for signer `kubernetes.io/kube-apiserver-client` (user + groups, omitting `system:authenticated`).
- If the token driver is in use but the registration subject is not yet present, return `SubjectNotReadyError` so registration stays pending and no hub RBAC is applied until the spoke publishes the subject.
- Otherwise (`kubeClientDriver` empty or `csr`), keep binding to `agent.DefaultUser(cluster, addonName, agentName)` (replacing the duplicated string).

## Related issue(s)

Fixes [open-cluster-management-io/managed-serviceaccount#279](https://github.com/open-cluster-management-io/managed-serviceaccount/issues/279)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved permission assignment for token-based cluster add-ons to correctly use registration credentials instead of default credentials
  * Enhanced error handling to prevent operations when required permissions aren't yet available

* **Tests**
  * Added test coverage for token-based add-on permission behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->