### PR TITLE
:bug: Fix managed-serviceaccount arm64 image builds

### DIFF
--- a/.github/workflows/go-postsubmit.yml
+++ b/.github/workflows/go-postsubmit.yml
@@ -41,7 +41,7 @@ jobs:
       - name: images
         run: |
           IMAGE_TAG=latest-${{ matrix.arch }} \
-          IMAGE_BUILD_EXTRA_FLAGS="--build-arg OS=linux --build-arg ARCH=${{ matrix.arch }}" \
+          IMAGE_BUILD_EXTRA_FLAGS="--platform linux/${{ matrix.arch }}" \
             make images
       - name: push
         run: |
@@ -95,7 +95,7 @@ jobs:
       - name: images
         run: |
           IMAGE_TAG=latest-${{ matrix.arch }} \
-          IMAGE_BUILD_EXTRA_FLAGS="--build-arg OS=linux --build-arg ARCH=${{ matrix.arch }}" \
+          IMAGE_BUILD_EXTRA_FLAGS="--platform linux/${{ matrix.arch }}" \
             make images-cp-creds
       - name: push
         run: |

--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -54,7 +54,7 @@ jobs:
       - name: images
         run: |
           IMAGE_TAG=${{ needs.env.outputs.RELEASE_VERSION }}-${{ matrix.arch }} \
-          IMAGE_BUILD_EXTRA_FLAGS="--build-arg OS=linux --build-arg ARCH=${{ matrix.arch }}" \
+          IMAGE_BUILD_EXTRA_FLAGS="--platform linux/${{ matrix.arch }}" \
             make images
       - name: push
         run: |
@@ -107,7 +107,7 @@ jobs:
       - name: images
         run: |
           IMAGE_TAG=${{ needs.env.outputs.RELEASE_VERSION }}-${{ matrix.arch }} \
-          IMAGE_BUILD_EXTRA_FLAGS="--build-arg OS=linux --build-arg ARCH=${{ matrix.arch }}" \
+          IMAGE_BUILD_EXTRA_FLAGS="--platform linux/${{ matrix.arch }}" \
             make images-cp-creds
       - name: push
         run: |
@@ -140,7 +140,7 @@ jobs:
   release:
     name: release
     runs-on: ubuntu-latest
-    needs: [ env, image-manifest ]
+    needs: [ env, image-manifest, image-manifest-cp-creds ]
     steps:
       - name: checkout code
         uses: actions/checkout@v6

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
-FROM golang:1.25-bookworm AS builder
+FROM --platform=$BUILDPLATFORM golang:1.25-bookworm AS builder
+ARG TARGETOS=linux
+ARG TARGETARCH
 WORKDIR /go/src/github.com/open-cluster-management.io/managed-serviceaccount
 COPY . .
-RUN go env
-RUN make build-bin
+RUN GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-$(go env GOHOSTARCH)} CGO_ENABLED=0 \
+    GO_BUILD_FLAGS='-trimpath -a' GO_BUILD_LDFLAGS='-s -w' make build-bin
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 COPY --from=builder /go/src/github.com/open-cluster-management.io/managed-serviceaccount/bin/msa /

--- a/Dockerfile.cp-creds
+++ b/Dockerfile.cp-creds
@@ -1,10 +1,9 @@
-FROM golang:1.25-bookworm AS builder
-ARG OS=linux
-ARG ARCH=amd64
+FROM --platform=$BUILDPLATFORM golang:1.25-bookworm AS builder
+ARG TARGETOS=linux
+ARG TARGETARCH
 WORKDIR /go/src/github.com/open-cluster-management.io/managed-serviceaccount
 COPY . .
-RUN go env
-RUN GOOS=${OS} GOARCH=${ARCH} CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -a -o bin/cp-creds cmd/clusterprofile-credentials-plugin/main.go
+RUN GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-$(go env GOHOSTARCH)} CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -a -o bin/cp-creds cmd/clusterprofile-credentials-plugin/main.go
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 COPY --from=builder /go/src/github.com/open-cluster-management.io/managed-serviceaccount/bin/cp-creds /

--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,10 @@ GOBIN=$(shell go env GOBIN)
 endif
 
 export DOCKER_BUILDER ?= docker
-export CGO_ENABLED = 1
+export CGO_ENABLED = 0
 export GOFLAGS ?=
+GO_BUILD_FLAGS ?= -a
+GO_BUILD_LDFLAGS ?=
 
 # Setting SHELL to bash allows bash commands to be executed by recipes.
 # Options are set to exit when a recipe line exits non-zero or a piped command fails.
@@ -73,7 +75,7 @@ test: manifests generate fmt vet envtest-setup ## Run tests.
 build: generate fmt vet build-bin
 
 build-bin:
-	go build -a -o bin/msa cmd/main.go
+	go build $(GO_BUILD_FLAGS) $(if $(GO_BUILD_LDFLAGS),-ldflags="$(GO_BUILD_LDFLAGS)") -o bin/msa cmd/main.go
 
 build-e2e:
 	go test -c -o bin/e2e ./e2e/
@@ -132,10 +134,10 @@ rm -rf $$TMP_DIR ;\
 endef
 
 images:
-	$(DOCKER_BUILDER) build -t ${IMG_REGISTRY}/managed-serviceaccount:${IMAGE_TAG} -f Dockerfile .
+	$(DOCKER_BUILDER) build ${IMAGE_BUILD_EXTRA_FLAGS} -t ${IMG_REGISTRY}/managed-serviceaccount:${IMAGE_TAG} -f Dockerfile .
 
 images-amd64:
-	$(DOCKER_BUILDER) build --platform linux/amd64 -t ${IMG_REGISTRY}/managed-serviceaccount:${IMAGE_TAG} -f Dockerfile .
+	$(DOCKER_BUILDER) build --platform linux/amd64 ${IMAGE_BUILD_EXTRA_FLAGS} -t ${IMG_REGISTRY}/managed-serviceaccount:${IMAGE_TAG} -f Dockerfile .
 
 images-cp-creds:
 	$(DOCKER_BUILDER) build ${IMAGE_BUILD_EXTRA_FLAGS} -t ${IMG_REGISTRY}/cp-creds:${IMAGE_TAG} -f Dockerfile.cp-creds .


### PR DESCRIPTION
## Summary

Build the managed-serviceaccount image with the requested target architecture so the arm64 variant contains an arm64 `/msa` binary.

## Related issue(s)

Fixes #300


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved multi-platform container image builds with enhanced cross-architecture compilation support and automatic platform-specific detection.
  * Updated CI/CD workflows and release pipelines to ensure consistent, reliable image generation with proper dependency ordering for multi-architecture manifest processing.
  * Parameterized build flags and configuration options for greater build flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->