### PR TITLE
:seedling: Improve template install e2e namespace error

### DIFF
--- a/e2e/install/template_install.go
+++ b/e2e/install/template_install.go
@@ -52,7 +52,7 @@ var _ = Describe("Template Addon Installation Test", Label("install"), Label("te
 				}
 
 				if addon.Status.Namespace != defaultNs {
-					return fmt.Errorf("addon is not installed in default namespace")
+					return fmt.Errorf("addon is not installed in default namespace %q, got %q", defaultNs, addon.Status.Namespace)
 				}
 				return nil
 			}).WithTimeout(time.Minute).ShouldNot(HaveOccurred())


### PR DESCRIPTION
## Summary

This updates the template install e2e assertion error so it reports both the expected default namespace and the actual addon status namespace.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved diagnostic messaging in end-to-end tests to provide clearer error reporting when addon installation fails, enabling faster issue identification during testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->