### PR TITLE
:bug: Reload agent when spoke kubeconfig changes

### DIFF
--- a/cmd/agent/agent.go
+++ b/cmd/agent/agent.go
@@ -235,7 +235,7 @@ func (o *AgentOptions) Run() error {
 		go leaseUpdater.Start(ctx)
 	}
 
-	cc, err := addonutils.NewConfigChecker("managed-serviceaccount-agent", getHubKubeconfigPath())
+	cc, err := addonutils.NewConfigChecker("managed-serviceaccount-agent", o.configCheckerPaths()...)
 	if err != nil {
 		klog.Fatalf("unable to create config checker for controller %v", "ManagedServiceAccount")
 	}
@@ -250,6 +250,14 @@ func (o *AgentOptions) Run() error {
 	}
 
 	return nil
+}
+
+func (o *AgentOptions) configCheckerPaths() []string {
+	paths := []string{getHubKubeconfigPath()}
+	if len(o.SpokeKubeconfig) > 0 {
+		paths = append(paths, o.SpokeKubeconfig)
+	}
+	return paths
 }
 
 // serveHealthProbes serves health probes and configchecker.

--- a/cmd/agent/agent_test.go
+++ b/cmd/agent/agent_test.go
@@ -1,0 +1,35 @@
+package agent
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConfigCheckerPaths(t *testing.T) {
+	t.Setenv("HUB_KUBECONFIG", "/etc/hub/kubeconfig")
+
+	cases := []struct {
+		name            string
+		spokeKubeconfig string
+		want            []string
+	}{
+		{
+			name: "default watches only the hub kubeconfig",
+			want: []string{"/etc/hub/kubeconfig"},
+		},
+		{
+			name:            "spoke kubeconfig also watched when provided",
+			spokeKubeconfig: "/etc/spoke/kubeconfig",
+			want:            []string{"/etc/hub/kubeconfig", "/etc/spoke/kubeconfig"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			opts := &AgentOptions{SpokeKubeconfig: tc.spokeKubeconfig}
+
+			assert.Equal(t, tc.want, opts.configCheckerPaths())
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Make the agent config checker watch the spoke kubeconfig path whenever `--spoke-kubeconfig` is provided, in addition to the hub kubeconfig. This lets the agent health/config check notice rotations of the managed-cluster kubeconfig instead of only reacting to hub kubeconfig changes.

## Related issue(s)

None.

## Tests

- `go test ./cmd/agent ./cmd/...`
