### PR TITLE
:sparkles: Add opt-in agent metrics scraping

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,61 @@ You can retrieve the token from the secret:
 kubectl -n <your-cluster-name> get secret my-sample -o jsonpath='{.data.token}' | base64 -d
 ```
 
+## Agent Metrics Scraping
+
+The addon agent exposes Prometheus metrics on port `38080`. The agent metrics
+`Service` is installed with the agent. Rendering a `ServiceMonitor` is opt-in
+and requires the Prometheus Operator `ServiceMonitor` CRD to already exist on
+the cluster where the agent is installed. The chart and addon do not install
+that CRD.
+
+The opt-in mechanism depends on the install mode:
+
+- In the default manager/agent Deployment mode, configure the target
+  `ManagedClusterAddOn` with an `AddOnDeploymentConfig`.
+- In AddOnTemplate mode, enable the ServiceMonitor in Helm values because the
+  agent workload is rendered into the `AddOnTemplate` at install time.
+
+Deployment mode example:
+
+```yaml
+apiVersion: addon.open-cluster-management.io/v1alpha1
+kind: AddOnDeploymentConfig
+metadata:
+  name: managed-serviceaccount-agent-metrics
+  namespace: <your-cluster-name>
+spec:
+  customizedVariables:
+  - name: AgentServiceMonitorEnabled
+    value: "true"
+  - name: AgentServiceMonitorLabels
+    value: "release=prometheus"
+---
+apiVersion: addon.open-cluster-management.io/v1alpha1
+kind: ManagedClusterAddOn
+metadata:
+  name: managed-serviceaccount
+  namespace: <your-cluster-name>
+spec:
+  configs:
+  - group: addon.open-cluster-management.io
+    resource: addondeploymentconfigs
+    namespace: <your-cluster-name>
+    name: managed-serviceaccount-agent-metrics
+```
+
+AddOnTemplate mode example:
+
+```shell
+helm install \
+    -n open-cluster-management-addon --create-namespace \
+    managed-serviceaccount ocm/managed-serviceaccount \
+    --set hubDeployMode=AddOnTemplate \
+    --set targetCluster=<your-cluster-name> \
+    --set agentMetrics.serviceMonitor.enabled=true \
+    --set agentMetrics.serviceMonitor.labels.release=prometheus
+```
+
 ## References
 
 - Design: [https://github.com/open-cluster-management-io/enhancements/tree/main/enhancements/sig-architecture/19-projected-serviceaccount-token](https://github.com/open-cluster-management-io/enhancements/tree/main/enhancements/sig-architecture/19-projected-serviceaccount-token)

--- a/charts/managed-serviceaccount/templates/addontemplate.yaml
+++ b/charts/managed-serviceaccount/templates/addontemplate.yaml
@@ -69,6 +69,10 @@ spec:
                 - agent
                 image: {{ .Values.image }}:{{ .Values.tag | default (print "v" .Chart.Version) }}
                 imagePullPolicy: IfNotPresent
+                ports:
+                - name: metrics
+                  containerPort: 38080
+                  protocol: TCP
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -77,6 +81,40 @@ spec:
                   periodSeconds: 10
                 name: addon-agent
               serviceAccount: managed-serviceaccount
+      - apiVersion: v1
+        kind: Service
+        metadata:
+          name: managed-serviceaccount-addon-agent
+          namespace: open-cluster-management-agent-addon
+          labels:
+            addon-agent: managed-serviceaccount
+        spec:
+          selector:
+            addon-agent: managed-serviceaccount
+          ports:
+          - name: metrics
+            port: 38080
+            targetPort: metrics
+            protocol: TCP
+{{ if .Values.agentMetrics.serviceMonitor.enabled }}
+      - apiVersion: monitoring.coreos.com/v1
+        kind: ServiceMonitor
+        metadata:
+          name: managed-serviceaccount-addon-agent
+          namespace: open-cluster-management-agent-addon
+{{ with .Values.agentMetrics.serviceMonitor.labels }}
+          labels:
+{{ toYaml . | indent 12 }}
+{{ end }}
+        spec:
+          endpoints:
+          - path: /metrics
+            scheme: http
+            port: metrics
+          selector:
+            matchLabels:
+              addon-agent: managed-serviceaccount
+{{ end }}
       - apiVersion: rbac.authorization.k8s.io/v1
         kind: Role
         metadata:

--- a/charts/managed-serviceaccount/values.yaml
+++ b/charts/managed-serviceaccount/values.yaml
@@ -12,6 +12,11 @@ featureGates:
 
 agentImagePullSecret: ""
 
+agentMetrics:
+  serviceMonitor:
+    enabled: false
+    labels: {}
+
 # Hub deploy mode: AddOnTemplate or Deployment
 hubDeployMode: Deployment
 

--- a/cmd/manager/manager.go
+++ b/cmd/manager/manager.go
@@ -211,7 +211,7 @@ func (o *HubManagerOptions) Run() error {
 			}
 		}
 
-		agentFactory := addonfactory.NewAgentAddonFactory(common.AddonName, manager.FS, "manifests/templates").
+		agentFactory := manager.NewAgentAddonFactory(common.AddonName, manager.FS, "manifests/templates").
 			WithConfigGVRs(utils.AddOnDeploymentConfigGVR).
 			WithGetValuesFuncs(
 				manager.GetDefaultValues(o.AddonAgentImageName, imagePullSecret),
@@ -222,7 +222,7 @@ func (o *HubManagerOptions) Run() error {
 				),
 				addonfactory.GetAddOnDeploymentConfigValues(
 					utils.NewAddOnDeploymentConfigGetter(addonClient),
-					addonfactory.ToAddOnDeploymentConfigValues,
+					manager.ToAddOnDeploymentConfigValues,
 				),
 			).
 			WithAgentRegistrationOption(manager.NewRegistrationOption(nativeClient)).

--- a/deploy/samples/addon-agent-metrics-scraping.yaml
+++ b/deploy/samples/addon-agent-metrics-scraping.yaml
@@ -1,0 +1,25 @@
+apiVersion: addon.open-cluster-management.io/v1alpha1
+kind: AddOnDeploymentConfig
+metadata:
+  name: managed-serviceaccount-agent-metrics
+  namespace: loopback
+spec:
+  customizedVariables:
+  - name: AgentServiceMonitorEnabled
+    value: "true"
+  # Labels are parsed as comma-separated key=value pairs.
+  - name: AgentServiceMonitorLabels
+    value: "release=prometheus"
+---
+apiVersion: addon.open-cluster-management.io/v1alpha1
+kind: ManagedClusterAddOn
+metadata:
+  name: managed-serviceaccount
+  namespace: loopback
+spec:
+  installNamespace: open-cluster-management-agent-addon
+  configs:
+  - group: addon.open-cluster-management.io
+    resource: addondeploymentconfigs
+    namespace: loopback
+    name: managed-serviceaccount-agent-metrics

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
 	github.com/stretchr/testify v1.11.1
+	helm.sh/helm/v3 v3.19.4
 	k8s.io/api v0.35.4
 	k8s.io/apimachinery v0.35.4
 	k8s.io/apiserver v0.35.4
@@ -20,6 +21,7 @@ require (
 	open-cluster-management.io/api v1.3.0
 	sigs.k8s.io/cluster-inventory-api v0.1.0
 	sigs.k8s.io/controller-runtime v0.23.3
+	sigs.k8s.io/yaml v1.6.0
 )
 
 require (
@@ -96,12 +98,10 @@ require (
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	helm.sh/helm/v3 v3.19.4 // indirect
 	k8s.io/apiextensions-apiserver v0.35.3 // indirect
 	k8s.io/kube-openapi v0.0.0-20260319004828-5883c5ee87b9 // indirect
 	open-cluster-management.io/sdk-go v1.2.0 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.2 // indirect
-	sigs.k8s.io/yaml v1.6.0 // indirect
 )

--- a/pkg/addon/manager/addon.go
+++ b/pkg/addon/manager/addon.go
@@ -4,11 +4,15 @@ import (
 	"context"
 	"embed"
 	"encoding/base64"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/utils/ptr"
 
@@ -22,15 +26,42 @@ import (
 //go:embed manifests/templates
 var FS embed.FS
 
+var serviceMonitorGroupVersion = schema.GroupVersion{
+	Group:   "monitoring.coreos.com",
+	Version: "v1",
+}
+
+func NewAgentAddonFactory(addonName string, fs embed.FS, dir string) *addonfactory.AgentAddonFactory {
+	scheme := runtime.NewScheme()
+	addServiceMonitorToScheme(scheme)
+	return addonfactory.NewAgentAddonFactory(addonName, fs, dir).WithScheme(scheme)
+}
+
+func addServiceMonitorToScheme(scheme *runtime.Scheme) {
+	scheme.AddKnownTypeWithName(
+		serviceMonitorGroupVersion.WithKind("ServiceMonitor"),
+		&unstructured.Unstructured{},
+	)
+	scheme.AddKnownTypeWithName(
+		serviceMonitorGroupVersion.WithKind("ServiceMonitorList"),
+		&unstructured.UnstructuredList{},
+	)
+	metav1.AddToGroupVersion(scheme, serviceMonitorGroupVersion)
+}
+
 func GetDefaultValues(image string, imagePullSecret *corev1.Secret) addonfactory.GetValuesFunc {
 	return func(cluster *clusterv1.ManagedCluster, addon *addonv1alpha1.ManagedClusterAddOn) (addonfactory.Values, error) {
 		manifestConfig := struct {
-			ClusterName         string
-			Image               string
-			ImagePullSecretData string
+			ClusterName                string
+			Image                      string
+			ImagePullSecretData        string
+			AgentServiceMonitorEnabled string
+			AgentServiceMonitorLabels  map[string]string
 		}{
-			ClusterName: cluster.Name,
-			Image:       image,
+			ClusterName:                cluster.Name,
+			Image:                      image,
+			AgentServiceMonitorEnabled: "false",
+			AgentServiceMonitorLabels:  map[string]string{},
 		}
 
 		if imagePullSecret != nil {
@@ -39,6 +70,32 @@ func GetDefaultValues(image string, imagePullSecret *corev1.Secret) addonfactory
 
 		return addonfactory.StructToValues(manifestConfig), nil
 	}
+}
+
+func ToAddOnDeploymentConfigValues(config addonv1alpha1.AddOnDeploymentConfig) (addonfactory.Values, error) {
+	values, err := addonfactory.ToAddOnDeploymentConfigValues(config)
+	if err != nil {
+		return nil, err
+	}
+
+	if raw, ok := values["AgentServiceMonitorLabels"].(string); ok {
+		values["AgentServiceMonitorLabels"] = parseServiceMonitorLabels(raw)
+	}
+
+	return values, nil
+}
+
+func parseServiceMonitorLabels(raw string) map[string]string {
+	labels := map[string]string{}
+	for _, item := range strings.Split(raw, ",") {
+		key, value, ok := strings.Cut(item, "=")
+		key = strings.TrimSpace(key)
+		if !ok || len(key) == 0 {
+			continue
+		}
+		labels[key] = strings.TrimSpace(value)
+	}
+	return labels
 }
 
 func NewRegistrationOption(nativeClient kubernetes.Interface) *agent.RegistrationOption {

--- a/pkg/addon/manager/addon_test.go
+++ b/pkg/addon/manager/addon_test.go
@@ -1,15 +1,22 @@
 package manager
 
 import (
+	"context"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	fakekube "k8s.io/client-go/kubernetes/fake"
 	clienttesting "k8s.io/client-go/testing"
 	"open-cluster-management.io/addon-framework/pkg/addonfactory"
+	"open-cluster-management.io/addon-framework/pkg/utils"
 	addonv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
 	"open-cluster-management.io/managed-serviceaccount/pkg/common"
@@ -46,6 +53,7 @@ func TestManifestAddonAgent(t *testing.T) {
 		"open-cluster-management:managed-serviceaccount:addon-agent",
 		"open-cluster-management:managed-serviceaccount:addon-agent",
 		"open-cluster-management:managed-serviceaccount:addon-agent",
+		"managed-serviceaccount-addon-agent",
 		"managed-serviceaccount-addon-agent",
 	}
 
@@ -87,6 +95,226 @@ func TestManifestAddonAgent(t *testing.T) {
 			}
 			assert.ElementsMatch(t, c.expectedManifestNames, actual)
 		})
+	}
+}
+
+func TestManifestAddonAgentMetricsServiceDefaultEnabled(t *testing.T) {
+	clusterName := "cluster1"
+	addonName := "addon1"
+	imageName := "imageName1"
+
+	manifests := renderTestManifests(
+		t,
+		newTestCluster(clusterName),
+		newTestAddOn(addonName, clusterName),
+		GetDefaultValues(imageName, nil),
+	)
+
+	assertDeploymentContainerPort(t, findDeployment(t, manifests, "managed-serviceaccount-addon-agent"), "metrics", 38080)
+	assertAgentMetricsService(t, findService(t, manifests, "managed-serviceaccount-addon-agent"))
+	assertNoServiceMonitor(t, manifests, "managed-serviceaccount-addon-agent")
+}
+
+func TestManifestAddonAgentServiceMonitorOptIn(t *testing.T) {
+	clusterName := "cluster1"
+	addonName := "addon1"
+	imageName := "imageName1"
+
+	manifests := renderTestManifests(
+		t,
+		newTestCluster(clusterName),
+		newTestAddOn(addonName, clusterName),
+		GetDefaultValues(imageName, nil),
+		func(cluster *clusterv1.ManagedCluster, addon *addonv1alpha1.ManagedClusterAddOn) (addonfactory.Values, error) {
+			return addonfactory.Values{
+				"AgentServiceMonitorEnabled": "true",
+			}, nil
+		},
+	)
+
+	assertAgentMetricsService(t, findService(t, manifests, "managed-serviceaccount-addon-agent"))
+	serviceMonitor := findServiceMonitor(t, manifests, "managed-serviceaccount-addon-agent")
+	assertAgentServiceMonitor(t, serviceMonitor)
+	assert.Empty(t, serviceMonitor.GetLabels())
+}
+
+func TestManifestAddonAgentServiceMonitorLabelsFromAddOnDeploymentConfig(t *testing.T) {
+	clusterName := "cluster1"
+	addonName := "addon1"
+	imageName := "imageName1"
+	addon := newTestAddOn(addonName, clusterName)
+	config := &addonv1alpha1.AddOnDeploymentConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "metrics-config",
+			Namespace: clusterName,
+		},
+		Spec: addonv1alpha1.AddOnDeploymentConfigSpec{
+			CustomizedVariables: []addonv1alpha1.CustomizedVariable{
+				{Name: "AgentServiceMonitorEnabled", Value: "true"},
+				{Name: "AgentServiceMonitorLabels", Value: "release=prometheus,team=platform"},
+			},
+		},
+	}
+	addon.Status.ConfigReferences = []addonv1alpha1.ConfigReference{
+		{
+			ConfigGroupResource: addonv1alpha1.ConfigGroupResource{
+				Group:    utils.AddOnDeploymentConfigGVR.Group,
+				Resource: utils.AddOnDeploymentConfigGVR.Resource,
+			},
+			DesiredConfig: &addonv1alpha1.ConfigSpecHash{
+				ConfigReferent: addonv1alpha1.ConfigReferent{
+					Namespace: config.Namespace,
+					Name:      config.Name,
+				},
+				SpecHash: "hash",
+			},
+		},
+	}
+
+	manifests := renderTestManifests(
+		t,
+		newTestCluster(clusterName),
+		addon,
+		GetDefaultValues(imageName, nil),
+		addonfactory.GetAddOnDeploymentConfigValues(
+			fakeAddOnDeploymentConfigGetter{config: config},
+			ToAddOnDeploymentConfigValues,
+		),
+	)
+
+	serviceMonitor := findServiceMonitor(t, manifests, "managed-serviceaccount-addon-agent")
+	assertAgentServiceMonitor(t, serviceMonitor)
+	assert.Equal(t, map[string]string{
+		"release": "prometheus",
+		"team":    "platform",
+	}, serviceMonitor.GetLabels())
+}
+
+func renderTestManifests(
+	t *testing.T,
+	cluster *clusterv1.ManagedCluster,
+	addon *addonv1alpha1.ManagedClusterAddOn,
+	getValuesFuncs ...addonfactory.GetValuesFunc,
+) []runtime.Object {
+	t.Helper()
+
+	agentFactory := NewAgentAddonFactory(common.AddonName, FS, "manifests/templates").
+		WithGetValuesFuncs(getValuesFuncs...)
+
+	addOnAgent, err := agentFactory.BuildTemplateAgentAddon()
+	assert.NoError(t, err)
+
+	manifests, err := addOnAgent.Manifests(cluster, addon)
+	assert.NoError(t, err)
+
+	return manifests
+}
+
+type fakeAddOnDeploymentConfigGetter struct {
+	config *addonv1alpha1.AddOnDeploymentConfig
+}
+
+func (g fakeAddOnDeploymentConfigGetter) Get(ctx context.Context, namespace, name string) (*addonv1alpha1.AddOnDeploymentConfig, error) {
+	if g.config == nil {
+		return nil, fmt.Errorf("addon deployment config %s/%s not found", namespace, name)
+	}
+	if g.config.Namespace != namespace || g.config.Name != name {
+		return nil, fmt.Errorf("addon deployment config %s/%s not found", namespace, name)
+	}
+	return g.config, nil
+}
+
+func findDeployment(t *testing.T, manifests []runtime.Object, name string) *appsv1.Deployment {
+	t.Helper()
+	for _, manifest := range manifests {
+		deployment, ok := manifest.(*appsv1.Deployment)
+		if ok && deployment.Name == name {
+			return deployment
+		}
+	}
+	t.Fatalf("deployment %q not found", name)
+	return nil
+}
+
+func findService(t *testing.T, manifests []runtime.Object, name string) *corev1.Service {
+	t.Helper()
+	for _, manifest := range manifests {
+		service, ok := manifest.(*corev1.Service)
+		if ok && service.Name == name {
+			return service
+		}
+	}
+	t.Fatalf("service %q not found", name)
+	return nil
+}
+
+func findServiceMonitor(t *testing.T, manifests []runtime.Object, name string) *unstructured.Unstructured {
+	t.Helper()
+	for _, manifest := range manifests {
+		serviceMonitor, ok := manifest.(*unstructured.Unstructured)
+		if ok && serviceMonitor.GetKind() == "ServiceMonitor" && serviceMonitor.GetName() == name {
+			return serviceMonitor
+		}
+	}
+	t.Fatalf("servicemonitor %q not found", name)
+	return nil
+}
+
+func assertNoServiceMonitor(t *testing.T, manifests []runtime.Object, name string) {
+	t.Helper()
+	for _, manifest := range manifests {
+		serviceMonitor, ok := manifest.(*unstructured.Unstructured)
+		if ok && serviceMonitor.GetKind() == "ServiceMonitor" && serviceMonitor.GetName() == name {
+			t.Fatalf("servicemonitor %q should not be rendered", name)
+		}
+	}
+}
+
+func assertDeploymentContainerPort(t *testing.T, deployment *appsv1.Deployment, name string, port int32) {
+	t.Helper()
+	for _, containerPort := range deployment.Spec.Template.Spec.Containers[0].Ports {
+		if containerPort.Name == name {
+			assert.Equal(t, port, containerPort.ContainerPort)
+			assert.Equal(t, corev1.ProtocolTCP, containerPort.Protocol)
+			return
+		}
+	}
+	t.Fatalf("container port %q not found", name)
+}
+
+func assertAgentMetricsService(t *testing.T, service *corev1.Service) {
+	t.Helper()
+	assert.Equal(t, "managed-serviceaccount-addon-agent", service.Name)
+	assert.Equal(t, map[string]string{"addon-agent": "managed-serviceaccount"}, service.Labels)
+	assert.Equal(t, map[string]string{"addon-agent": "managed-serviceaccount"}, service.Spec.Selector)
+	if assert.Len(t, service.Spec.Ports, 1) {
+		assert.Equal(t, "metrics", service.Spec.Ports[0].Name)
+		assert.Equal(t, int32(38080), service.Spec.Ports[0].Port)
+		assert.Equal(t, intstr.FromString("metrics"), service.Spec.Ports[0].TargetPort)
+		assert.Equal(t, corev1.ProtocolTCP, service.Spec.Ports[0].Protocol)
+	}
+}
+
+func assertAgentServiceMonitor(t *testing.T, serviceMonitor *unstructured.Unstructured) {
+	t.Helper()
+	assert.Equal(t, "monitoring.coreos.com/v1", serviceMonitor.GetAPIVersion())
+	assert.Equal(t, "ServiceMonitor", serviceMonitor.GetKind())
+
+	endpoints, ok, err := unstructured.NestedSlice(serviceMonitor.Object, "spec", "endpoints")
+	assert.NoError(t, err)
+	if assert.True(t, ok, "ServiceMonitor endpoints should be set") && assert.Len(t, endpoints, 1) {
+		endpoint, ok := endpoints[0].(map[string]interface{})
+		if assert.True(t, ok, "endpoint should be an object") {
+			assert.Equal(t, "/metrics", endpoint["path"])
+			assert.Equal(t, "http", endpoint["scheme"])
+			assert.Equal(t, "metrics", endpoint["port"])
+		}
+	}
+
+	selector, ok, err := unstructured.NestedStringMap(serviceMonitor.Object, "spec", "selector", "matchLabels")
+	assert.NoError(t, err)
+	if assert.True(t, ok, "ServiceMonitor selector should be set") {
+		assert.Equal(t, map[string]string{"addon-agent": "managed-serviceaccount"}, selector)
 	}
 }
 

--- a/pkg/addon/manager/chart_test.go
+++ b/pkg/addon/manager/chart_test.go
@@ -1,0 +1,311 @@
+package manager_test
+
+import (
+	"path/filepath"
+	"reflect"
+	goruntime "runtime"
+	"strings"
+	"testing"
+
+	"helm.sh/helm/v3/pkg/chart/loader"
+	"helm.sh/helm/v3/pkg/chartutil"
+	"helm.sh/helm/v3/pkg/engine"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	apiruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"sigs.k8s.io/yaml"
+)
+
+const (
+	addOnTemplateTemplate = "managed-serviceaccount/templates/addontemplate.yaml"
+
+	releaseNamespace = "open-cluster-management-addon"
+	agentNamespace   = "open-cluster-management-agent-addon"
+	agentName        = "managed-serviceaccount-addon-agent"
+	agentLabelKey    = "addon-agent"
+	agentLabelValue  = "managed-serviceaccount"
+)
+
+func chartDir(t *testing.T) string {
+	t.Helper()
+	_, filename, _, ok := goruntime.Caller(0)
+	if !ok {
+		t.Fatal("unable to determine chart test file location")
+	}
+	return filepath.Join(filepath.Dir(filename), "..", "..", "..", "charts", "managed-serviceaccount")
+}
+
+func renderChart(t *testing.T, values map[string]interface{}) map[string]string {
+	t.Helper()
+	c, err := loader.Load(chartDir(t))
+	if err != nil {
+		t.Fatalf("load chart: %v", err)
+	}
+
+	vals, err := chartutil.ToRenderValues(
+		c,
+		values,
+		chartutil.ReleaseOptions{Name: "msa", Namespace: releaseNamespace, IsInstall: true},
+		chartutil.DefaultCapabilities,
+	)
+	if err != nil {
+		t.Fatalf("compose render values: %v", err)
+	}
+
+	out, err := engine.Render(c, vals)
+	if err != nil {
+		t.Fatalf("render chart: %v", err)
+	}
+	return out
+}
+
+func rendered(out map[string]string, key string) string {
+	return strings.TrimSpace(out[key])
+}
+
+func renderAddOnTemplate(t *testing.T, out map[string]string) *unstructured.Unstructured {
+	t.Helper()
+	raw := rendered(out, addOnTemplateTemplate)
+	if raw == "" {
+		return nil
+	}
+
+	obj := map[string]interface{}{}
+	if err := yaml.Unmarshal([]byte(raw), &obj); err != nil {
+		t.Fatalf("decode %s: %v\n%s", addOnTemplateTemplate, err, raw)
+	}
+	return &unstructured.Unstructured{Object: obj}
+}
+
+func TestAddOnTemplateAgentMetricsDefault(t *testing.T) {
+	addOnTemplate := renderAddOnTemplate(t, renderChart(t, map[string]interface{}{
+		"hubDeployMode": "AddOnTemplate",
+	}))
+
+	assertAgentDeploymentMetrics(t, embeddedManifestAs[appsv1.Deployment](
+		t, addOnTemplate, "apps/v1", "Deployment", agentName,
+	))
+	assertAgentMetricsService(t, embeddedManifestAs[corev1.Service](
+		t, addOnTemplate, "v1", "Service", agentName,
+	))
+	assertNoEmbeddedManifest(t, addOnTemplate, "monitoring.coreos.com/v1", "ServiceMonitor", agentName)
+}
+
+func TestAddOnTemplateAgentServiceMonitorOptIn(t *testing.T) {
+	addOnTemplate := renderAddOnTemplate(t, renderChart(t, map[string]interface{}{
+		"hubDeployMode": "AddOnTemplate",
+		"agentMetrics": map[string]interface{}{
+			"serviceMonitor": map[string]interface{}{
+				"enabled": true,
+				"labels": map[string]interface{}{
+					"release": "prometheus",
+				},
+			},
+		},
+	}))
+
+	serviceMonitor := &unstructured.Unstructured{
+		Object: findEmbeddedManifest(t, addOnTemplate, "monitoring.coreos.com/v1", "ServiceMonitor", agentName),
+	}
+	assertAgentServiceMonitor(t, serviceMonitor, map[string]string{
+		"release": "prometheus",
+	})
+}
+
+func TestDeploymentModeDoesNotRenderAddOnTemplate(t *testing.T) {
+	if raw := rendered(renderChart(t, map[string]interface{}{}), addOnTemplateTemplate); raw != "" {
+		t.Fatalf("expected AddOnTemplate template to be gated off in Deployment mode, got:\n%s", raw)
+	}
+}
+
+func embeddedManifestAs[T any](
+	t *testing.T,
+	addOnTemplate *unstructured.Unstructured,
+	apiVersion, kind, name string,
+) *T {
+	t.Helper()
+	manifest := findEmbeddedManifest(t, addOnTemplate, apiVersion, kind, name)
+	var obj T
+	if err := apiruntime.DefaultUnstructuredConverter.FromUnstructured(manifest, &obj); err != nil {
+		t.Fatalf("convert %s/%s %s: %v", apiVersion, kind, name, err)
+	}
+	return &obj
+}
+
+func findEmbeddedManifest(
+	t *testing.T,
+	addOnTemplate *unstructured.Unstructured,
+	apiVersion, kind, name string,
+) map[string]interface{} {
+	t.Helper()
+	if addOnTemplate == nil {
+		t.Fatal("expected AddOnTemplate to render")
+	}
+
+	manifests, ok, err := unstructured.NestedSlice(addOnTemplate.Object, "spec", "agentSpec", "workload", "manifests")
+	if err != nil {
+		t.Fatalf("get AddOnTemplate workload manifests: %v", err)
+	}
+	if !ok {
+		t.Fatal("AddOnTemplate workload manifests not found")
+	}
+
+	for _, item := range manifests {
+		manifest, ok := item.(map[string]interface{})
+		if !ok {
+			t.Fatalf("unexpected manifest item %#v", item)
+		}
+		if manifest["apiVersion"] != apiVersion || manifest["kind"] != kind {
+			continue
+		}
+		metadata, ok := manifest["metadata"].(map[string]interface{})
+		if !ok {
+			t.Fatalf("manifest metadata is missing: %#v", manifest)
+		}
+		if metadata["name"] == name {
+			return manifest
+		}
+	}
+
+	t.Fatalf("embedded manifest %s/%s %s not found", apiVersion, kind, name)
+	return nil
+}
+
+func assertNoEmbeddedManifest(
+	t *testing.T,
+	addOnTemplate *unstructured.Unstructured,
+	apiVersion, kind, name string,
+) {
+	t.Helper()
+	if addOnTemplate == nil {
+		t.Fatal("expected AddOnTemplate to render")
+	}
+
+	manifests, ok, err := unstructured.NestedSlice(addOnTemplate.Object, "spec", "agentSpec", "workload", "manifests")
+	if err != nil {
+		t.Fatalf("get AddOnTemplate workload manifests: %v", err)
+	}
+	if !ok {
+		t.Fatal("AddOnTemplate workload manifests not found")
+	}
+
+	for _, item := range manifests {
+		manifest, ok := item.(map[string]interface{})
+		if !ok {
+			t.Fatalf("unexpected manifest item %#v", item)
+		}
+		if manifest["apiVersion"] != apiVersion || manifest["kind"] != kind {
+			continue
+		}
+		metadata, ok := manifest["metadata"].(map[string]interface{})
+		if !ok {
+			t.Fatalf("manifest metadata is missing: %#v", manifest)
+		}
+		if metadata["name"] == name {
+			t.Fatalf("embedded manifest %s/%s %s should not render", apiVersion, kind, name)
+		}
+	}
+}
+
+func assertAgentDeploymentMetrics(t *testing.T, deployment *appsv1.Deployment) {
+	t.Helper()
+	if deployment.Name != agentName {
+		t.Fatalf("unexpected Deployment name %q", deployment.Name)
+	}
+	if deployment.Namespace != agentNamespace {
+		t.Fatalf("unexpected Deployment namespace %q", deployment.Namespace)
+	}
+	if len(deployment.Spec.Template.Spec.Containers) != 1 {
+		t.Fatalf("expected one agent container, got %#v", deployment.Spec.Template.Spec.Containers)
+	}
+	for _, port := range deployment.Spec.Template.Spec.Containers[0].Ports {
+		if port.Name == "metrics" {
+			if port.ContainerPort != 38080 {
+				t.Fatalf("unexpected metrics containerPort %d", port.ContainerPort)
+			}
+			if port.Protocol != corev1.ProtocolTCP {
+				t.Fatalf("unexpected metrics protocol %q", port.Protocol)
+			}
+			return
+		}
+	}
+	t.Fatalf("metrics container port not found in %#v", deployment.Spec.Template.Spec.Containers[0].Ports)
+}
+
+func assertAgentMetricsService(t *testing.T, service *corev1.Service) {
+	t.Helper()
+	if service.Name != agentName {
+		t.Fatalf("unexpected Service name %q", service.Name)
+	}
+	if service.Namespace != agentNamespace {
+		t.Fatalf("unexpected Service namespace %q", service.Namespace)
+	}
+	if !reflect.DeepEqual(service.Labels, map[string]string{agentLabelKey: agentLabelValue}) {
+		t.Fatalf("unexpected Service labels %#v", service.Labels)
+	}
+	if !reflect.DeepEqual(service.Spec.Selector, map[string]string{agentLabelKey: agentLabelValue}) {
+		t.Fatalf("unexpected Service selector %#v", service.Spec.Selector)
+	}
+	if len(service.Spec.Ports) != 1 {
+		t.Fatalf("expected one Service port, got %#v", service.Spec.Ports)
+	}
+	servicePort := service.Spec.Ports[0]
+	if servicePort.Name != "metrics" {
+		t.Fatalf("unexpected Service port name %q", servicePort.Name)
+	}
+	if servicePort.Port != 38080 {
+		t.Fatalf("unexpected Service port %d", servicePort.Port)
+	}
+	if servicePort.TargetPort != intstr.FromString("metrics") {
+		t.Fatalf("unexpected Service targetPort %q", servicePort.TargetPort.String())
+	}
+	if servicePort.Protocol != corev1.ProtocolTCP {
+		t.Fatalf("unexpected Service protocol %q", servicePort.Protocol)
+	}
+}
+
+func assertAgentServiceMonitor(t *testing.T, serviceMonitor *unstructured.Unstructured, labels map[string]string) {
+	t.Helper()
+	if serviceMonitor.GetAPIVersion() != "monitoring.coreos.com/v1" {
+		t.Fatalf("unexpected ServiceMonitor apiVersion %q", serviceMonitor.GetAPIVersion())
+	}
+	if serviceMonitor.GetKind() != "ServiceMonitor" {
+		t.Fatalf("unexpected ServiceMonitor kind %q", serviceMonitor.GetKind())
+	}
+	if serviceMonitor.GetName() != agentName {
+		t.Fatalf("unexpected ServiceMonitor name %q", serviceMonitor.GetName())
+	}
+	if serviceMonitor.GetNamespace() != agentNamespace {
+		t.Fatalf("unexpected ServiceMonitor namespace %q", serviceMonitor.GetNamespace())
+	}
+	if !reflect.DeepEqual(serviceMonitor.GetLabels(), labels) {
+		t.Fatalf("unexpected ServiceMonitor labels %#v", serviceMonitor.GetLabels())
+	}
+
+	endpoints, ok, err := unstructured.NestedSlice(serviceMonitor.Object, "spec", "endpoints")
+	if err != nil {
+		t.Fatalf("get ServiceMonitor endpoints: %v", err)
+	}
+	if !ok || len(endpoints) != 1 {
+		t.Fatalf("expected one ServiceMonitor endpoint, got %#v", endpoints)
+	}
+	endpoint, ok := endpoints[0].(map[string]interface{})
+	if !ok {
+		t.Fatalf("unexpected ServiceMonitor endpoint %#v", endpoints[0])
+	}
+	for key, want := range map[string]string{"path": "/metrics", "scheme": "http", "port": "metrics"} {
+		if endpoint[key] != want {
+			t.Fatalf("unexpected ServiceMonitor endpoint %s=%#v, want %q", key, endpoint[key], want)
+		}
+	}
+
+	selector, ok, err := unstructured.NestedStringMap(serviceMonitor.Object, "spec", "selector", "matchLabels")
+	if err != nil {
+		t.Fatalf("get ServiceMonitor selector: %v", err)
+	}
+	if !ok || !reflect.DeepEqual(selector, map[string]string{agentLabelKey: agentLabelValue}) {
+		t.Fatalf("unexpected ServiceMonitor selector %#v", selector)
+	}
+}

--- a/pkg/addon/manager/manifests/templates/deployment.yaml
+++ b/pkg/addon/manager/manifests/templates/deployment.yaml
@@ -44,6 +44,10 @@ spec:
             - --cluster-name={{ .ClusterName }}
             - --kubeconfig=/etc/hub/kubeconfig
             - --lease-health-check=true
+          ports:
+            - name: metrics
+              containerPort: 38080
+              protocol: TCP
           volumeMounts:
             - name: hub-kubeconfig
               mountPath: /etc/hub/

--- a/pkg/addon/manager/manifests/templates/metrics_service.yaml
+++ b/pkg/addon/manager/manifests/templates/metrics_service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: managed-serviceaccount-addon-agent
+  namespace: {{ .AddonInstallNamespace }}
+  labels:
+    addon-agent: managed-serviceaccount
+spec:
+  selector:
+    addon-agent: managed-serviceaccount
+  ports:
+    - name: metrics
+      port: 38080
+      targetPort: metrics
+      protocol: TCP

--- a/pkg/addon/manager/manifests/templates/service_monitor.yaml
+++ b/pkg/addon/manager/manifests/templates/service_monitor.yaml
@@ -1,0 +1,21 @@
+{{ if eq .AgentServiceMonitorEnabled "true" }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: managed-serviceaccount-addon-agent
+  namespace: {{ .AddonInstallNamespace }}
+{{- if .AgentServiceMonitorLabels }}
+  labels:
+{{- range $key, $value := .AgentServiceMonitorLabels }}
+    {{ $key }}: "{{ $value }}"
+{{- end }}
+{{- end }}
+spec:
+  endpoints:
+    - path: /metrics
+      scheme: http
+      port: metrics
+  selector:
+    matchLabels:
+      addon-agent: managed-serviceaccount
+{{ end }}


### PR DESCRIPTION
## Summary

The addon agent was already listening on a metrics endpoint, but it was not discoverable by Prometheus-based scraping because no Service or ServiceMonitor was created for it. This change always creates a metrics Service for the agent and adds an opt-in ServiceMonitor configuration through AddOnDeploymentConfig.

A sample manifest is also added to show how to enable ServiceMonitor scraping and configure its labels.

## Related issue(s)

None.
