### PR TITLE
:seedling: Build cp-creds image in presubmit

### DIFF
--- a/.github/workflows/go-presubmit.yml
+++ b/.github/workflows/go-presubmit.yml
@@ -30,6 +30,15 @@ jobs:
       - name: build
         run: make build
 
+  images-cp-creds:
+    name: images-cp-creds
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout code
+        uses: actions/checkout@v6
+      - name: images-cp-creds
+        run: make images-cp-creds
+
   unit:
     name: unit
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Add a presubmit job that builds the `Dockerfile.cp-creds` image on pull requests. The existing e2e jobs exercise the main image through `make images`, but the cp-creds image was only covered later, so this keeps the second Dockerfile and its build context path covered before merge.

## Related issue(s)

None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a new build validation step to the continuous integration pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->