### PR TITLE
:sparkles: Add hosted mode addon support

### DIFF
--- a/.github/workflows/go-presubmit.yml
+++ b/.github/workflows/go-presubmit.yml
@@ -126,6 +126,18 @@ jobs:
   e2e:
     name: e2e
     runs-on: ubuntu-latest
+    # Leaves headroom over the suite and environment-setup step timeouts, so a
+    # step timeout fails the step instead of the job timeout cancelling the
+    # if-failure diagnostics dump.
+    timeout-minutes: 150
+    # Topology of the hosting-cluster phase, shared by hack/e2e/setup-hosted.sh,
+    # the hosted suite and hack/e2e/dump.sh. The scripts keep their own defaults
+    # so they still run standalone.
+    env:
+      KUBECONFIG_DIR: ${{ github.workspace }}/_output/e2e/kubeconfigs
+      HOSTING_CLUSTER_NAME: hosting
+      SPOKE_CLUSTER_NAME: spoke
+      HOSTED_INSTALL_NAMESPACE: msa-spoke
     steps:
       - name: checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -166,18 +178,57 @@ jobs:
              --set tag=latest \
              --set featureGates.ephemeralIdentity=true \
              --set featureGates.clusterProfile=true
-      - name: Run e2e test
-        run: make test-e2e
+      # Run the full e2e suite once for each supported agent placement.
+      # Step-level timeouts keep a hung suite a step failure; a job-level
+      # timeout cancels the job and skips the if-failure diagnostics dump.
+      - name: Run e2e with agent on managed cluster
+        id: e2e-managed-cluster-agent
+        continue-on-error: true
+        timeout-minutes: 35
+        run: |
+          make test-e2e GENKGO_ARGS='--ginkgo.junit-report=_output/e2e/reports/e2e-managed-cluster-agent.xml'
+          make test-e2e-cleanup GENKGO_ARGS='--ginkgo.junit-report=_output/e2e/reports/e2e-managed-cluster-agent-cleanup.xml'
+      - name: Prepare hosting-cluster e2e environment
+        timeout-minutes: 20
+        run: bash hack/e2e/setup-hosted.sh
+      - name: Run e2e with agent on hosting cluster
+        id: e2e-hosted-agent
+        continue-on-error: true
+        timeout-minutes: 45
+        env:
+          E2E_TEST_CLUSTER_NAME: ${{ env.SPOKE_CLUSTER_NAME }}
+          HUB_KUBECONFIG: ${{ env.KUBECONFIG_DIR }}/hub.kubeconfig
+          SPOKE_KUBECONFIG: ${{ env.KUBECONFIG_DIR }}/${{ env.SPOKE_CLUSTER_NAME }}.kubeconfig
+          AGENT_KUBECONFIG: ${{ env.KUBECONFIG_DIR }}/${{ env.HOSTING_CLUSTER_NAME }}.kubeconfig
+        run: |
+          # deployment-install re-rolls the agent twice on a 2m budget sized
+          # for the managed-cluster phase; the hosted rollout path needs more,
+          # so skip it in this phase.
+          make test-e2e-hosted GENKGO_ARGS='--ginkgo.label-filter='\''!deployment-install'\'' --ginkgo.junit-report=_output/e2e/reports/e2e-hosted-agent.xml'
+          make test-e2e-cleanup-hosted GENKGO_ARGS='--ginkgo.junit-report=_output/e2e/reports/e2e-hosted-agent-cleanup.xml'
+      - name: Upload e2e reports
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: e2e-reports
+          path: _output/e2e/reports/*.xml
+          if-no-files-found: ignore
+      # Both e2e steps are continue-on-error so that every suite gets to report,
+      # so this step is what turns a suite failure into a job failure.
+      - name: Report e2e result
+        if: always()
+        env:
+          MANAGED_CLUSTER_AGENT_OUTCOME: ${{ steps.e2e-managed-cluster-agent.outcome }}
+          HOSTED_AGENT_OUTCOME: ${{ steps.e2e-hosted-agent.outcome }}
+        run: |
+          if [[ "$MANAGED_CLUSTER_AGENT_OUTCOME" != success ||
+                "$HOSTED_AGENT_OUTCOME" != success ]]; then
+            echo "e2e failed: managed-cluster-agent=$MANAGED_CLUSTER_AGENT_OUTCOME hosted-agent=$HOSTED_AGENT_OUTCOME" >&2
+            exit 1
+          fi
       - name: Dump e2e diagnostics
         if: failure()
-        run: |
-          kubectl get clustermanagementaddon managed-serviceaccount -o yaml || true
-          kubectl get managedclusteraddon -A -o yaml || true
-          kubectl get addondeploymentconfig -A -o yaml || true
-          kubectl get manifestwork -A -o yaml || true
-          kubectl get deploy,po,sa,role,rolebinding -A | grep -E 'managed-serviceaccount|open-cluster-management-agent-addon|open-cluster-management-addon' || true
-          kubectl get pod -A | grep -i addon || true
-          kubectl -n open-cluster-management-addon logs deploy/managed-serviceaccount-addon-manager --all-containers --tail=-1 || true
+        run: bash hack/e2e/dump.sh
 
   e2e-addon-template:
     name: e2e-addon-template

--- a/Makefile
+++ b/Makefile
@@ -97,6 +97,14 @@ test-helm: verify-helm-dependencies ## Lint and render Helm charts.
 		--namespace open-cluster-management-agent-addon \
 		--set Prometheus.Enabled=true \
 		--set imagePullSecretData=dGVzdA== >/dev/null
+	$(HELM) template managed-serviceaccount-agent pkg/addon/manager/manifests/charts/managed-serviceaccount-agent \
+		--namespace msa-spoke \
+		--set installMode=Hosted \
+		--set clusterName=spoke \
+		--set addonInstallNamespace=msa-spoke \
+		--set networkPolicies.enabled=true \
+		--set Prometheus.Enabled=true \
+		--set imagePullSecretData=dGVzdA== >/dev/null
 
 ##@ Build
 
@@ -107,6 +115,10 @@ build-bin:
 
 build-e2e:
 	go test -c -o bin/e2e ./e2e/
+
+.PHONY: build-e2e-cleanup
+build-e2e-cleanup:
+	go test -c -o bin/e2e-cleanup ./e2e/cleanup/
 
 run: manifests generate fmt vet ## Run a controller from your host.
 	go run ./main.go
@@ -178,6 +190,50 @@ test-integration:
 
 test-e2e: build-e2e
 	./bin/e2e --test-cluster $(E2E_TEST_CLUSTER_NAME) $(GENKGO_ARGS)
+
+.PHONY: test-e2e-cleanup
+test-e2e-cleanup: build-e2e-cleanup
+	./bin/e2e-cleanup --test-cluster $(E2E_TEST_CLUSTER_NAME) $(GENKGO_ARGS)
+
+# E2e variables for an agent running on a hosting cluster
+# (see README "Running the agent on a hosting cluster").
+HUB_KUBECONFIG ?=
+SPOKE_KUBECONFIG ?=
+AGENT_KUBECONFIG ?=
+EXTERNAL_MANAGED_KUBECONFIG_NAMESPACE ?=
+EXTERNAL_MANAGED_KUBECONFIG_SECRET ?=
+HOSTING_CLUSTER_NAME ?=
+HOSTED_INSTALL_NAMESPACE ?=
+
+HOSTED_E2E_ARGS = \
+	--hub-kubeconfig "$(HUB_KUBECONFIG)" \
+	--spoke-kubeconfig "$(SPOKE_KUBECONFIG)" \
+	--agent-kubeconfig "$(AGENT_KUBECONFIG)" \
+	--hosting-cluster-name "$(HOSTING_CLUSTER_NAME)" \
+	--hosted-install-namespace "$(HOSTED_INSTALL_NAMESPACE)" \
+	--external-managed-kubeconfig-namespace "$(EXTERNAL_MANAGED_KUBECONFIG_NAMESPACE)" \
+	--external-managed-kubeconfig-secret "$(EXTERNAL_MANAGED_KUBECONFIG_SECRET)"
+
+# The e2e binary validates every flag it receives; only the two variables whose
+# absence it cannot detect are checked here. An unset HUB_KUBECONFIG silently
+# falls back to ~/.kube/config, and an unset HOSTING_CLUSTER_NAME silently runs
+# the suite against an agent on the managed cluster.
+.PHONY: verify-hosted-e2e-variables
+verify-hosted-e2e-variables:
+	@missing=; \
+	[ -n "$(HUB_KUBECONFIG)" ]       || missing="$$missing HUB_KUBECONFIG"; \
+	[ -n "$(HOSTING_CLUSTER_NAME)" ] || missing="$$missing HOSTING_CLUSTER_NAME"; \
+	if [ -n "$$missing" ]; then \
+		echo "hosted e2e: required variables not set:$$missing" >&2; \
+		exit 1; \
+	fi
+
+.PHONY: test-e2e-hosted test-e2e-cleanup-hosted
+test-e2e-hosted: verify-hosted-e2e-variables build-e2e
+	./bin/e2e --test-cluster $(E2E_TEST_CLUSTER_NAME) $(HOSTED_E2E_ARGS) $(GENKGO_ARGS)
+
+test-e2e-cleanup-hosted: verify-hosted-e2e-variables build-e2e-cleanup
+	./bin/e2e-cleanup --test-cluster $(E2E_TEST_CLUSTER_NAME) $(HOSTED_E2E_ARGS) $(GENKGO_ARGS)
 
 code-gen: client-gen lister-gen informer-gen ## Generate clientset, listers and informers
 	hack/code_gen.sh

--- a/README.md
+++ b/README.md
@@ -14,24 +14,45 @@ This addon is beneficial when you need to:
 
 ## Architecture
 
-The addon follows the standard OCM [addon architecture](https://open-cluster-management.io/concepts/addon/) with two main components:
+The addon follows the standard OCM [addon architecture](https://open-cluster-management.io/concepts/addon/).
+It supports two addon agent placements. `installMode` is an addon-framework
+render value passed to the agent chart, not a value of the hub Helm chart:
+
+- **Agent on the managed cluster** (`installMode=Default`): the addon agent runs
+  on the cluster it manages.
+- **Agent on a hosting cluster** (`installMode=Hosted`): the addon agent and a
+  kubeconfig provisioner run on a separate hosting cluster, while the
+  managed-side identity and RBAC remain on the managed cluster.
 
 **Addon Manager**
-- Automatically installs the addon agent into managed clusters
-- Manages required resources and dependencies
+- Renders and distributes resources for both agent placements
+- Manages registration, placement, configuration, and required resources
 
 **Addon Agent**  
 - Monitors the ManagedServiceAccount API resources
-- Periodically projects service account tokens as secret resources to the hub cluster
+- Manages service accounts and requests their tokens through the managed-cluster API
+- Periodically projects those tokens as secret resources to the hub cluster
 - Handles token refresh according to the configured rotation policy
+
+**Managed Kubeconfig Provisioner (agent on a hosting cluster only)**
+- Uses an external managed-cluster kubeconfig to mint a short-lived token for
+  the agent's managed-cluster service account
+- Generates the agent's managed-cluster kubeconfig; the target klusterlet's
+  addon registration agent creates and rotates the hub kubeconfig on the
+  hosting cluster as configured by addon-framework
 
 ### Installation Methods
 
 The managed service account addon supports 2 installation ways:
 
-- **default (manager - agent)**: Full deployment with both addon manager and addon agent components.
-- **addontemplate**: Addon-manager driven install with the addon agent by default. Enabling
-  `featureGates.clusterProfile=true` also deploys the hub manager.
+- **`hubDeployMode=Deployment` (addon-framework manager - agent)**: Full deployment with both addon manager and addon agent components.
+  This is the only installation method that supports placing an agent on a
+  hosting cluster. The addon manager runs under the hub manager's leader
+  election. When replacing an AddOnTemplate installation, it also preserves
+  Lease-based addon health reporting.
+- **`hubDeployMode=AddOnTemplate`**: Addon-manager driven install with the addon agent by default. Enabling
+  `featureGates.clusterProfile=true` also deploys the hub manager. Placing an
+  agent on a hosting cluster is not supported with this installation method.
 
 ## Installation
 
@@ -81,9 +102,10 @@ Set `prometheus.enabled=true` to expose addon metrics with Prometheus
 `deploy/samples/addon-agent-metrics-scraping.yaml` for an example.
 
 The Prometheus Operator `ServiceMonitor` CRD must exist on the cluster where the
-ServiceMonitor is applied: the hub cluster for manager metrics, and the managed
-cluster for agent metrics. If the CRD is missing, the installation or addon
-status reports the apply failure.
+ServiceMonitor is applied: the hub cluster for manager metrics, the managed
+cluster for metrics from an agent running on the managed cluster, and the
+hosting cluster for metrics from an agent running there. If the CRD is missing,
+installation fails or the add-on status reports an apply failure.
 
 ### Creating a ManagedServiceAccount
 
@@ -149,7 +171,319 @@ You can retrieve the token from the secret:
 kubectl -n <your-cluster-name> get secret my-sample -o jsonpath='{.data.token}' | base64 -d
 ```
 
+## Running the agent on a hosting cluster
+
+In this placement, the addon agent runs on a hosting cluster instead of the
+managed cluster. The managed cluster still contains the managed-side service
+account and RBAC used by the agent; the addon registration secret (hub
+kubeconfig) is created and rotated on the hosting cluster where the agent
+runs. The hub addon manager renders the hosted workloads. This placement is
+supported only by the addon-framework manager installed with
+`hubDeployMode=Deployment`; it is not supported with
+`hubDeployMode=AddOnTemplate`. Configure it through
+`ManagedClusterAddOn` and `AddOnDeploymentConfig`.
+
+### Architecture and credential flow
+
+```mermaid
+flowchart LR
+  subgraph hub["Hub cluster"]
+    addon["ManagedClusterAddOn<br/>AddOnDeploymentConfig"]
+    manager["Managed ServiceAccount<br/>addon manager"]
+    hubState["ManagedServiceAccount resources<br/>projected token Secrets"]
+  end
+
+  subgraph hosting["Hosting cluster"]
+    source["Source namespace<br/>external managed kubeconfig Secret"]
+    provisioner["Managed kubeconfig<br/>provisioner"]
+    runtime["Dedicated addon namespace<br/>managed kubeconfig Secret<br/>hub kubeconfig Secret"]
+    agent["Hosted addon agent"]
+    lease["Addon health Lease"]
+    registration["Target addon registration agent<br/>(co-located klusterlet)"]
+  end
+
+  subgraph managed["Managed cluster"]
+    identity["Agent ServiceAccount<br/>and RBAC"]
+    managedAPI["Managed API<br/>ServiceAccount and TokenRequest"]
+  end
+
+  addon --> manager
+  manager -->|hosting manifests| provisioner
+  manager -->|hosting manifests| agent
+  manager -->|managed manifests| identity
+  source --> provisioner
+  provisioner -->|read agent identity and mint token| managedAPI
+  registration -->|create and rotate hub kubeconfig| runtime
+  provisioner -->|managed kubeconfig| runtime
+  runtime -->|two kubeconfigs| agent
+  agent -->|watch resources and write token Secrets| hubState
+  agent -->|reconcile service accounts and request tokens| managedAPI
+  agent -->|renew| lease
+  lease -->|observed locally| registration
+  registration -->|report health| addon
+```
+
+### Prerequisites
+
+Three pieces of state must exist before the agent can run on a hosting cluster:
+
+1. On the hub, annotate the `ManagedClusterAddOn` with the hosting cluster name
+   so addon-framework places hosted manifests on that cluster. Also set
+   `AddOnDeploymentConfig.spec.agentInstallNamespace` to a namespace on the
+   hosting cluster dedicated to this managed-serviceaccount addon instance.
+   That namespace must be unique to this managed cluster:
+
+    ```yaml
+    apiVersion: addon.open-cluster-management.io/v1beta1
+    kind: AddOnDeploymentConfig
+    metadata:
+      name: managed-serviceaccount-hosted
+      namespace: <managed-cluster-name>
+    spec:
+      agentInstallNamespace: msa-<managed-cluster-name>
+    ---
+    apiVersion: addon.open-cluster-management.io/v1beta1
+    kind: ManagedClusterAddOn
+    metadata:
+      name: managed-serviceaccount
+      namespace: <managed-cluster-name>
+      annotations:
+        addon.open-cluster-management.io/hosting-cluster-name: <hosting-cluster-name>
+        addon.open-cluster-management.io/v1alpha1-install-namespace: msa-<managed-cluster-name>
+    spec:
+      configs:
+        - group: addon.open-cluster-management.io
+          resource: addondeploymentconfigs
+          namespace: <managed-cluster-name>
+          name: managed-serviceaccount-hosted
+    ```
+
+   The target managed cluster must already use a hosted klusterlet. Set
+   `addon.open-cluster-management.io/hosting-cluster-name` to the same cluster
+   that runs the target klusterlet's registration and work agents. The current
+   addon-framework implementation verifies only that the named hosting cluster
+   is managed by the hub; it does not verify this co-location. If the annotation
+   points to another managed cluster, the addon workloads may be applied there
+   while the target registration-agent cannot observe their health Lease,
+   leaving the addon `Available` condition `Unknown`.
+
+   Hosted templates render fixed object names for the agent, kubeconfig
+   provisioner, generated managed kubeconfig secret, and their RBAC in
+   `AddonInstallNamespace`, so each managed cluster needs its own namespace on
+   the hosting cluster. Hosted mode rejects the Default-mode namespace
+   `open-cluster-management-agent-addon` even when it is explicitly configured;
+   that namespace is reserved for an addon running directly on the cluster.
+   The addon manager also enforces uniqueness across every
+   managed-serviceaccount agent placed on the same cluster, including a Default
+   mode agent for the hosting cluster itself. The addon already holding a
+   namespace in `status.namespace` keeps it; between unclaimed addons, the older
+   one wins. The other fails to render with `cannot use install namespace ...:
+   already used by ...`. Depending on placement and reconciliation progress,
+   the rejected addon reports the error in `ManifestApplied` or
+   `HostingManifestApplied`. An addon rejected at creation may show no status at
+   all, so also check the addon manager logs. An addon keeps defending its
+   claimed namespace through `status.namespace` until its
+   `ManagedClusterAddOn` is deleted, even if its configuration can no longer be
+   resolved. Do not use the hosted klusterlet agent namespace here; that
+   namespace owns the hosted klusterlet's bootstrap and hub kubeconfig secrets,
+   and an addon namespace change can delete addon-owned namespace manifests.
+
+   Do not directly swap the namespaces of two hosted addons. Each addon keeps
+   its current `status.namespace` claim until cleanup finishes, so a direct swap
+   leaves both waiting for the other. Move one addon to an unused temporary
+   namespace, wait for its status and old resources to move, move the second
+   addon to its final namespace, and then move the first addon from the
+   temporary namespace to its final namespace.
+
+2. On the hosting cluster, create the external managed kubeconfig secret in a
+   namespace named after the managed cluster by default. This follows the
+   hosted-addon pattern used by OCM addons such as cluster-proxy: the external
+   managed kubeconfig is an input to the addon provisioner, while the addon
+   install namespace is where generated runtime secrets are written. The
+   default location is separate from the hosted klusterlet's
+   `external-managed-kubeconfig`, which lives in the klusterlet agent namespace
+   (`klusterlet-<cluster>` by default). The source namespace and secret variables
+   can instead point directly to that or another compatible Secret; the chart
+   grants the provisioner read access to the selected Secret. The provisioner
+   reads its `kubeconfig` data key, then uses that kubeconfig only to mint a
+   short-lived token for the managed service account.
+   It never writes the external bootstrap credentials into the generated
+   managed kubeconfig Secret mounted by the addon agent. The target klusterlet's
+   addon registration agent creates and rotates the hub kubeconfig on the
+   hosting cluster as configured by addon-framework; the provisioner does not
+   manage it.
+
+   The external managed kubeconfig must be self-contained. Embed the CA and user
+   credentials inline with fields such as `certificate-authority-data`,
+   `client-certificate-data`, `client-key-data`, or `token`. As with the
+   klusterlet's `external-managed-kubeconfig` secret, file-based
+   `client-certificate` and `client-key` references are accepted when the
+   secret bundles `tls.crt` and `tls.key` entries; the provisioner embeds them
+   automatically. Other file-based `certificate-authority`, `client-certificate`,
+   `client-key`, `tokenFile`, `exec`, and `auth-provider` credentials are
+   rejected because those paths, binaries, or local provider state would not
+   exist inside the provisioner pod.
+   Its API server endpoint must also resolve and be reachable from the
+   provisioner and agent pods inside the hosting cluster; runner-only
+   connectivity is insufficient. The embedded CA must be valid for that
+   endpoint.
+
+3. On the managed cluster, grant the external managed kubeconfig identity
+   permission to read the target service account and mint tokens for it. The
+   provisioner first reads the service account and then calls
+   `ServiceAccounts(<install-namespace>).CreateToken(<managed-serviceaccount-name>, ...)`.
+   The minimum RBAC is:
+
+    ```yaml
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: Role
+    metadata:
+      namespace: msa-<managed-cluster-name>
+      name: managed-serviceaccount-kubeconfig-provisioner
+    rules:
+      - apiGroups: [""]
+        resources: ["serviceaccounts"]
+        resourceNames: ["managed-serviceaccount"]
+        verbs: ["get"]
+      - apiGroups: [""]
+        resources: ["serviceaccounts/token"]
+        resourceNames: ["managed-serviceaccount"]
+        verbs: ["create"]
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      namespace: msa-<managed-cluster-name>
+      name: managed-serviceaccount-kubeconfig-provisioner
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: Role
+      name: managed-serviceaccount-kubeconfig-provisioner
+    subjects:
+      - kind: ServiceAccount
+        name: <bootstrap-serviceaccount-name>
+        namespace: <bootstrap-serviceaccount-namespace>
+    ```
+
+   Set the subject to the identity used by the external managed kubeconfig.
+   For User or Group credentials, change `kind` and `name`, set
+   `apiGroup: rbac.authorization.k8s.io`, and omit `namespace`.
+
+### AddOnDeploymentConfig Variables
+
+The hub manager renders hosted workloads from the variables below. Each can
+be overridden per managed cluster with
+`AddOnDeploymentConfig.spec.customizedVariables`.
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `externalManagedKubeConfigNamespace` | managed cluster name | Hosting-cluster namespace that holds the external managed kubeconfig secret. Override this only when the secret lives elsewhere. |
+| `externalManagedKubeConfigSecret` | `external-managed-kubeconfig` | External managed kubeconfig secret name on the hosting cluster. Must contain a `kubeconfig` key. |
+| `managedServiceAccountName` | `managed-serviceaccount` | Service account on the managed cluster whose token is stored in the generated runtime Secret. Applies in both install modes; in Default mode the agent runs as it. |
+| `managedKubeConfigTokenExpirationSeconds` | `3600` | Requested `TokenRequest` lifetime in seconds (`600` through `4294967296`). |
+| `managedKubeConfigRefreshBefore` | `10m` | Refresh the generated secret when the token expires within this duration. |
+| `managedKubeConfigProvisionerSyncInterval` | `5m` | Maximum reconcile interval for source changes. Token refresh runs earlier when required by the actual expiration returned by the API server. |
+
+The hub kubeconfig secret name comes from the addon-framework registration
+default, `managed-serviceaccount-hub-kubeconfig`. The registration flow always
+manages that name, so the addon manager rejects a `customizedVariables` entry
+named `hubKubeConfigSecret` instead of rendering an agent that points to a
+Secret that will never be created.
+
+The managed kubeconfig secret name also comes from the addon framework, as
+`managedKubeConfigSecret`, and defaults to `<addon-name>-managed-kubeconfig`.
+This is the hosting-cluster secret in the addon install namespace that the
+provisioner creates and the agent mounts at `/etc/managed/kubeconfig`. Override
+it through `customizedVariables` under that exact name to select a non-default
+name. The provisioner refuses to adopt a pre-existing unowned Secret.
+
+The generated managed kubeconfig Secret contains a stable `kubeconfig` entry
+whose user references `/etc/managed/token` through `tokenFile`, a separate
+`token` entry, and expiration metadata. The kubelet syncs the updated Secret
+volume into the running pod, allowing client-go to reload a rotated token
+without restarting the agent. The provisioner schedules refresh from the actual
+`TokenRequest.status.expirationTimestamp`, even when it is earlier than the
+requested lifetime.
+
+Customized token expiration must be within the Kubernetes TokenRequest API
+range of 600 through 4294967296 seconds. Refresh-before and sync-interval values
+must be positive, and refresh-before must be shorter than the requested token
+lifetime. Omit a variable to use its documented default.
+
+The generated managed kubeconfig Secret is controlled by the provisioner's
+ServiceAccount in the dedicated addon namespace. Deleting the hosted addon
+deletes that ServiceAccount and Kubernetes garbage collection removes the
+Secret. The provisioner refuses to adopt or overwrite an unowned managed
+kubeconfig Secret, so do not pre-create it.
+
+Example: point the provisioner at a non-default external managed kubeconfig
+secret and lengthen the token lifetime.
+
+```yaml
+apiVersion: addon.open-cluster-management.io/v1beta1
+kind: AddOnDeploymentConfig
+metadata:
+  name: managed-serviceaccount-hosted
+  namespace: <managed-cluster-name>
+spec:
+  agentInstallNamespace: msa-<managed-cluster-name>
+  customizedVariables:
+    - name: externalManagedKubeConfigNamespace
+      value: <managed-cluster-name>
+    - name: externalManagedKubeConfigSecret
+      value: my-managed-kubeconfig
+    - name: managedKubeConfigTokenExpirationSeconds
+      value: "7200"
+    - name: managedKubeConfigRefreshBefore
+      value: "15m"
+```
+
+Reference the config from the `ManagedClusterAddOn`:
+
+```yaml
+spec:
+  configs:
+    - group: addon.open-cluster-management.io
+      resource: addondeploymentconfigs
+      namespace: <managed-cluster-name>
+      name: managed-serviceaccount-hosted
+```
+
+### Running hosted E2E locally
+
+After preparing registered hub, hosting, and target clusters and installing the
+Deployment-mode hub manager, export the topology used by the suite:
+
+```shell
+export E2E_TEST_CLUSTER_NAME=spoke
+export HUB_KUBECONFIG="$PWD/_output/e2e/kubeconfigs/hub.kubeconfig"
+export SPOKE_KUBECONFIG="$PWD/_output/e2e/kubeconfigs/spoke.kubeconfig"
+export AGENT_KUBECONFIG="$PWD/_output/e2e/kubeconfigs/hosting.kubeconfig"
+export HOSTING_CLUSTER_NAME=hosting
+export HOSTED_INSTALL_NAMESPACE=msa-spoke
+export EXTERNAL_MANAGED_KUBECONFIG_NAMESPACE=spoke
+export EXTERNAL_MANAGED_KUBECONFIG_SECRET=external-managed-kubeconfig
+
+make test-e2e-hosted
+make test-e2e-cleanup-hosted
+```
+
+The external kubeconfig variables may be omitted to use the suite defaults: the
+target managed cluster name and `external-managed-kubeconfig`.
+
+### Internal CLI Surface
+
+Running the agent on a hosting cluster adds binary CLI surface only so the addon
+manager can wire the hosted workloads: `msa managed-kubeconfig-provisioner` runs
+in the provisioner Deployment and `msa agent` runs in the hosted agent
+Deployment. Their flags are rendered from the manifests and the
+`AddOnDeploymentConfig` variables above. Configure this placement through
+`ManagedClusterAddOn` and `AddOnDeploymentConfig`, not by invoking these commands
+manually.
+
 ## References
 
-- Design: [https://github.com/open-cluster-management-io/enhancements/tree/main/enhancements/sig-architecture/19-projected-serviceaccount-token](https://github.com/open-cluster-management-io/enhancements/tree/main/enhancements/sig-architecture/19-projected-serviceaccount-token)
+- Original ManagedServiceAccount design: [Projected ServiceAccount token (Enhancement 19)](https://github.com/open-cluster-management-io/enhancements/tree/main/enhancements/sig-architecture/19-projected-serviceaccount-token)
+- Hosted addon architecture (provisional): [Running addon agents outside the managed cluster (Enhancement 63)](https://github.com/open-cluster-management-io/enhancements/tree/main/enhancements/sig-architecture/63-hosted-addon)
+- Hosted deployment implementation: [addon-framework `hosted_sync.go`](https://github.com/open-cluster-management-io/addon-framework/blob/main/pkg/addonmanager/controllers/agentdeploy/hosted_sync.go)
 - Addon-Framework: [https://github.com/open-cluster-management-io/addon-framework](https://github.com/open-cluster-management-io/addon-framework)

--- a/charts/managed-serviceaccount/README.md
+++ b/charts/managed-serviceaccount/README.md
@@ -50,7 +50,10 @@ addon-framework default namespace `open-cluster-management-agent-addon` unless a
 ### Hub Manager Deployment
 
 `hubDeployMode=Deployment` installs the hub addon manager. The manager renders
-the embedded agent chart for each managed cluster through addon-framework.
+the embedded agent chart for each managed cluster through addon-framework. This
+is the only deployment mode that supports placing an agent on a hosting cluster.
+See [Running the agent on a hosting cluster](../../README.md#running-the-agent-on-a-hosting-cluster)
+for its prerequisites and per-cluster configuration.
 
 ```bash
 helm install managed-serviceaccount ./charts/managed-serviceaccount \
@@ -73,7 +76,8 @@ helm install managed-serviceaccount ./charts/managed-serviceaccount \
 
 `hubDeployMode=AddOnTemplate` renders an `AddOnTemplate` and the hub RBAC needed
 by addon-manager. When `featureGates.clusterProfile=true`, the chart also renders
-the hub manager so ClusterProfile credential sync can run.
+the hub manager so ClusterProfile credential sync can run. It cannot place an
+agent on a hosting cluster; use `hubDeployMode=Deployment` for a hosted agent.
 
 ```bash
 helm install managed-serviceaccount ./charts/managed-serviceaccount \

--- a/charts/managed-serviceaccount/helm_render_test.go
+++ b/charts/managed-serviceaccount/helm_render_test.go
@@ -3,9 +3,11 @@ package managedserviceaccount_test
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"io"
 	"os"
 	"os/exec"
+	"slices"
 	"testing"
 	"time"
 
@@ -51,6 +53,31 @@ func TestTargetClusterManagedClusterAddOnRendersConfig(t *testing.T) {
 	assertAddOnDeploymentConfigRef(t, configs[0], "loopback")
 }
 
+// Pinned at the verb level because losing this verb only surfaces as a slow
+// e2e cleanup failure; other rules are covered by structural render checks.
+func TestDeploymentModeManagerCanDeleteManifestWorks(t *testing.T) {
+	objects := renderChart(t)
+	role := findObject(t, objects, "ClusterRole", "", "open-cluster-management:managed-serviceaccount:addon-manager")
+
+	for _, rawRule := range mustNestedSlice(t, role.Object, "rules") {
+		rule, ok := rawRule.(map[string]interface{})
+		if !ok {
+			t.Fatalf("unexpected policy rule type %T", rawRule)
+		}
+		apiGroups := mustNestedStringSlice(t, rule, "apiGroups")
+		resources := mustNestedStringSlice(t, rule, "resources")
+		verbs := mustNestedStringSlice(t, rule, "verbs")
+		if slices.Contains(apiGroups, "work.open-cluster-management.io") &&
+			slices.Contains(resources, "manifestworks") {
+			if !slices.Contains(verbs, "delete") {
+				t.Fatalf("manifestwork policy rule must include delete: %v", verbs)
+			}
+			return
+		}
+	}
+	t.Fatal("manifestwork policy rule not found")
+}
+
 func TestAddOnTemplateModeRendersTemplateAndOmitsHubManager(t *testing.T) {
 	objects := renderChart(t, "--set", "hubDeployMode=AddOnTemplate")
 
@@ -69,6 +96,7 @@ func TestAddOnTemplateModeRendersTemplateAndOmitsHubManager(t *testing.T) {
 	assertObjectNotFound(t, objects, "Deployment", releaseNamespace, "managed-serviceaccount-addon-manager")
 	assertObjectNotFound(t, objects, "ServiceAccount", releaseNamespace, "managed-serviceaccount")
 	assertObjectNotFound(t, objects, "Service", releaseNamespace, "managed-serviceaccount-addon-manager-metrics")
+	assertAddOnTemplateDoesNotProvideHostedMode(t, addOnTemplate)
 }
 
 func TestAddOnTemplateModeWithClusterProfileRendersHubManager(t *testing.T) {
@@ -193,6 +221,19 @@ func mustNestedSlice(t *testing.T, object map[string]interface{}, fields ...stri
 	return values
 }
 
+func mustNestedStringSlice(t *testing.T, object map[string]interface{}, fields ...string) []string {
+	t.Helper()
+
+	values, found, err := unstructured.NestedStringSlice(object, fields...)
+	if err != nil {
+		t.Fatalf("failed to read field %v: %v", fields, err)
+	}
+	if !found {
+		t.Fatalf("missing field %v", fields)
+	}
+	return values
+}
+
 func assertNestedFieldNotFound(t *testing.T, object map[string]interface{}, fields ...string) {
 	t.Helper()
 
@@ -249,6 +290,25 @@ func assertAddOnTemplateDefaultConfig(t *testing.T, raw interface{}, name string
 	}
 	if ref["name"] != name {
 		t.Fatalf("unexpected default config name %v, want %s", ref["name"], name)
+	}
+}
+
+func assertAddOnTemplateDoesNotProvideHostedMode(t *testing.T, addOnTemplate *unstructured.Unstructured) {
+	t.Helper()
+
+	rendered, err := json.Marshal(addOnTemplate.Object)
+	if err != nil {
+		t.Fatalf("failed to serialize AddOnTemplate: %v", err)
+	}
+	for _, hostedOnly := range []string{
+		"addon.open-cluster-management.io/hosted-manifest-location",
+		"kubeconfig-provisioner",
+		"--install-mode=Hosted",
+		"--spoke-kubeconfig=",
+	} {
+		if bytes.Contains(rendered, []byte(hostedOnly)) {
+			t.Fatalf("AddOnTemplate mode must not contain hosted-only configuration %q", hostedOnly)
+		}
 	}
 }
 

--- a/charts/managed-serviceaccount/templates/clusterrole.yaml
+++ b/charts/managed-serviceaccount/templates/clusterrole.yaml
@@ -146,6 +146,7 @@ rules:
       - create
       - update
       - patch
+      - delete
   - apiGroups:
       - coordination.k8s.io
     resources:

--- a/charts/managed-serviceaccount/values.schema.json
+++ b/charts/managed-serviceaccount/values.schema.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "hubDeployMode": {
+      "type": "string",
+      "enum": [
+        "Deployment",
+        "AddOnTemplate"
+      ]
+    }
+  }
+}

--- a/cmd/agent/agent.go
+++ b/cmd/agent/agent.go
@@ -3,7 +3,7 @@ package agent
 import (
 	"context"
 	"crypto/tls"
-	"flag"
+	"fmt"
 	"net/http"
 	"os"
 	"strings"
@@ -15,6 +15,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/kubernetes"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
@@ -27,6 +28,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
+	addonconstants "open-cluster-management.io/addon-framework/pkg/addonmanager/constants"
+	addonlease "open-cluster-management.io/addon-framework/pkg/lease"
 	addonutils "open-cluster-management.io/addon-framework/pkg/utils"
 	authv1beta1 "open-cluster-management.io/managed-serviceaccount/apis/authentication/v1beta1"
 	"open-cluster-management.io/managed-serviceaccount/pkg/addon/agent/controller"
@@ -36,6 +39,8 @@ import (
 	"open-cluster-management.io/managed-serviceaccount/pkg/features"
 	"open-cluster-management.io/managed-serviceaccount/pkg/util"
 )
+
+const managedHealthRequestTimeout = 30 * time.Second
 
 var (
 	scheme = runtime.NewScheme()
@@ -72,6 +77,8 @@ func (o *AgentOptions) AddFlags(flags *pflag.FlagSet) {
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
 	flags.StringVar(&o.ClusterName, "cluster-name", "", "The name of the managed cluster.")
+	flags.StringVar(&o.InstallMode, "install-mode", addonconstants.InstallModeDefault,
+		"The install mode of the addon agent. Options are Default and Hosted.")
 	flags.StringVar(&o.SpokeKubeconfig, "spoke-kubeconfig", "", "The kubeconfig to talk to the managed cluster, "+
 		"will use the in-cluster client if not specified.")
 	flags.Var(
@@ -89,6 +96,7 @@ type AgentOptions struct {
 	ProbeAddr            string
 	FeatureGatesFlags    map[string]bool
 	ClusterName          string
+	InstallMode          string
 	SpokeKubeconfig      string
 	LeaseHealthCheck     bool
 }
@@ -101,8 +109,11 @@ func NewAgentOptions() *AgentOptions {
 func (o *AgentOptions) Run() error {
 	logger := klog.Background()
 	klog.SetOutput(os.Stdout)
-	klog.InitFlags(flag.CommandLine)
 	ctrl.SetLogger(logger)
+
+	if err := o.validateInstallMode(); err != nil {
+		return err
+	}
 
 	err := features.FeatureGates.SetFromMap(o.FeatureGatesFlags)
 	if err != nil {
@@ -228,7 +239,27 @@ func (o *AgentOptions) Run() error {
 	defer cancel()
 
 	if o.LeaseHealthCheck {
-		leaseUpdater, err := health.NewAddonHealthUpdater(mgr.GetConfig(), o.ClusterName, spokeCfg, spokeNamespace)
+		leaseCfg, err := leaseClientConfig(o.InstallMode, spokeCfg, rest.InClusterConfig)
+		if err != nil {
+			klog.Fatalf("failed to build a lease client config: %v", err)
+		}
+		var healthChecks []func() bool
+		if healthCfg := managedHealthClientConfig(o.InstallMode, spokeCfg); healthCfg != nil {
+			managedDiscovery, err := discovery.NewDiscoveryClientForConfig(healthCfg)
+			if err != nil {
+				klog.Fatalf("failed to build managed cluster health client: %v", err)
+			}
+			healthChecks = leaseHealthCheckFuncs(o.InstallMode, managedDiscovery)
+		}
+		// spokeNamespace doubles as the agent pod's own namespace, which is
+		// where the lease lives on whichever cluster leaseCfg points at.
+		leaseUpdater, err := health.NewAddonHealthUpdater(
+			mgr.GetConfig(),
+			o.ClusterName,
+			leaseCfg,
+			spokeNamespace,
+			healthChecks...,
+		)
 		if err != nil {
 			klog.Fatalf("unable to create healthiness lease updater for controller %v", "ManagedServiceAccount")
 		}
@@ -252,12 +283,53 @@ func (o *AgentOptions) Run() error {
 	return nil
 }
 
+func managedHealthClientConfig(installMode string, spokeCfg *rest.Config) *rest.Config {
+	if installMode != addonconstants.InstallModeHosted {
+		return nil
+	}
+	managedHealthCfg := rest.CopyConfig(spokeCfg)
+	managedHealthCfg.Timeout = managedHealthRequestTimeout
+	return managedHealthCfg
+}
+
+func leaseHealthCheckFuncs(installMode string, managedDiscovery discovery.DiscoveryInterface) []func() bool {
+	if installMode != addonconstants.InstallModeHosted {
+		return nil
+	}
+	return []func() bool{addonlease.CheckManagedClusterHealthFunc(managedDiscovery)}
+}
+
+func (o *AgentOptions) validateInstallMode() error {
+	switch o.InstallMode {
+	case addonconstants.InstallModeDefault:
+		return nil
+	case addonconstants.InstallModeHosted:
+		if len(o.SpokeKubeconfig) == 0 {
+			return fmt.Errorf("--spoke-kubeconfig is required when --install-mode=%s", addonconstants.InstallModeHosted)
+		}
+		return nil
+	default:
+		return fmt.Errorf("unsupported --install-mode %q, must be %q or %q",
+			o.InstallMode, addonconstants.InstallModeDefault, addonconstants.InstallModeHosted)
+	}
+}
+
 func (o *AgentOptions) configCheckerPaths() []string {
 	paths := []string{getHubKubeconfigPath()}
 	if len(o.SpokeKubeconfig) > 0 {
 		paths = append(paths, o.SpokeKubeconfig)
 	}
 	return paths
+}
+
+// leaseClientConfig returns the client config for the cluster holding the
+// addon health lease: the cluster the agent runs on in Hosted mode, the spoke
+// cluster otherwise.
+func leaseClientConfig(installMode string, spokeCfg *rest.Config, inClusterConfig func() (*rest.Config, error)) (*rest.Config, error) {
+	if installMode == addonconstants.InstallModeHosted {
+		return inClusterConfig()
+	}
+	return spokeCfg, nil
 }
 
 // serveHealthProbes serves health probes and configchecker.

--- a/cmd/agent/agent_test.go
+++ b/cmd/agent/agent_test.go
@@ -2,8 +2,13 @@ package agent
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	fakediscovery "k8s.io/client-go/discovery/fake"
+	"k8s.io/client-go/rest"
+	clienttesting "k8s.io/client-go/testing"
+	addonconstants "open-cluster-management.io/addon-framework/pkg/addonmanager/constants"
 )
 
 func TestConfigCheckerPaths(t *testing.T) {
@@ -15,21 +20,112 @@ func TestConfigCheckerPaths(t *testing.T) {
 		want            []string
 	}{
 		{
-			name: "default watches only the hub kubeconfig",
+			name: "agent on managed cluster watches only the hub kubeconfig",
 			want: []string{"/etc/hub/kubeconfig"},
 		},
 		{
-			name:            "spoke kubeconfig also watched when provided",
-			spokeKubeconfig: "/etc/spoke/kubeconfig",
-			want:            []string{"/etc/hub/kubeconfig", "/etc/spoke/kubeconfig"},
+			name:            "agent on hosting cluster also watches the rotating managed kubeconfig",
+			spokeKubeconfig: "/etc/managed/kubeconfig",
+			want:            []string{"/etc/hub/kubeconfig", "/etc/managed/kubeconfig"},
 		},
 	}
 
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			opts := &AgentOptions{SpokeKubeconfig: tc.spokeKubeconfig}
-
-			assert.Equal(t, tc.want, opts.configCheckerPaths())
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			opts := &AgentOptions{SpokeKubeconfig: c.spokeKubeconfig}
+			assert.Equal(t, c.want, opts.configCheckerPaths())
 		})
 	}
+}
+
+func TestValidateInstallMode(t *testing.T) {
+	cases := []struct {
+		name          string
+		opts          AgentOptions
+		expectedError string
+	}{
+		{
+			name: "accepts agent on managed cluster without spoke kubeconfig",
+			opts: AgentOptions{InstallMode: addonconstants.InstallModeDefault},
+		},
+		{
+			name:          "rejects empty install mode",
+			opts:          AgentOptions{},
+			expectedError: `unsupported --install-mode "", must be "Default" or "Hosted"`,
+		},
+		{
+			name: "accepts agent on hosting cluster with spoke kubeconfig",
+			opts: AgentOptions{InstallMode: addonconstants.InstallModeHosted, SpokeKubeconfig: "/etc/managed/kubeconfig"},
+		},
+		{
+			name:          "rejects agent on hosting cluster without spoke kubeconfig",
+			opts:          AgentOptions{InstallMode: addonconstants.InstallModeHosted},
+			expectedError: "--spoke-kubeconfig is required when --install-mode=Hosted",
+		},
+		{
+			name:          "rejects invalid install mode",
+			opts:          AgentOptions{InstallMode: "Detached"},
+			expectedError: `unsupported --install-mode "Detached", must be "Default" or "Hosted"`,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := c.opts.validateInstallMode()
+			if len(c.expectedError) > 0 {
+				assert.EqualError(t, err, c.expectedError)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestLeaseClientConfig(t *testing.T) {
+	spokeCfg := &rest.Config{Host: "https://spoke.example.com"}
+	inClusterCfg := &rest.Config{Host: "https://hosting.example.com"}
+
+	cases := []struct {
+		name        string
+		installMode string
+		expected    *rest.Config
+	}{
+		{
+			name:        "default mode writes the lease to the spoke cluster",
+			installMode: addonconstants.InstallModeDefault,
+			expected:    spokeCfg,
+		},
+		{
+			name:        "hosted mode writes the lease to the cluster the agent runs on",
+			installMode: addonconstants.InstallModeHosted,
+			expected:    inClusterCfg,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			cfg, err := leaseClientConfig(c.installMode, spokeCfg, func() (*rest.Config, error) {
+				return inClusterCfg, nil
+			})
+			assert.NoError(t, err)
+			assert.Same(t, c.expected, cfg)
+		})
+	}
+}
+
+func TestLeaseHealthCheckFuncs(t *testing.T) {
+	discoveryClient := &fakediscovery.FakeDiscovery{Fake: &clienttesting.Fake{}}
+
+	assert.Empty(t, leaseHealthCheckFuncs(addonconstants.InstallModeDefault, discoveryClient))
+	assert.Len(t, leaseHealthCheckFuncs(addonconstants.InstallModeHosted, discoveryClient), 1)
+}
+
+func TestManagedHealthClientConfig(t *testing.T) {
+	spokeCfg := &rest.Config{Host: "https://managed.example", Timeout: time.Minute}
+
+	assert.Nil(t, managedHealthClientConfig(addonconstants.InstallModeDefault, spokeCfg))
+	hostedCfg := managedHealthClientConfig(addonconstants.InstallModeHosted, spokeCfg)
+	assert.NotSame(t, spokeCfg, hostedCfg)
+	assert.Equal(t, managedHealthRequestTimeout, hostedCfg.Timeout)
+	assert.Equal(t, time.Minute, spokeCfg.Timeout)
 }

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -8,12 +8,15 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	utilflag "k8s.io/component-base/cli/flag"
+	"k8s.io/klog/v2"
 
 	"open-cluster-management.io/managed-serviceaccount/cmd/agent"
 	hub "open-cluster-management.io/managed-serviceaccount/cmd/manager"
+	"open-cluster-management.io/managed-serviceaccount/cmd/provisioner"
 )
 
 func main() {
+	klog.InitFlags(goflag.CommandLine)
 	pflag.CommandLine.SetNormalizeFunc(utilflag.WordSepNormalizeFunc)
 	pflag.CommandLine.AddGoFlagSet(goflag.CommandLine)
 
@@ -36,6 +39,7 @@ func newCommand() *cobra.Command {
 
 	cmd.AddCommand(hub.NewManager())
 	cmd.AddCommand(agent.NewAgent())
+	cmd.AddCommand(provisioner.NewProvisioner())
 
 	return cmd
 }

--- a/cmd/manager/manager.go
+++ b/cmd/manager/manager.go
@@ -18,7 +18,7 @@ package manager
 
 import (
 	"context"
-	"flag"
+	"fmt"
 	"os"
 	"strings"
 
@@ -29,6 +29,7 @@ import (
 	"github.com/spf13/pflag"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -39,12 +40,15 @@ import (
 	"k8s.io/klog/v2"
 	cpv1alpha1 "sigs.k8s.io/cluster-inventory-api/apis/v1alpha1"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	"open-cluster-management.io/addon-framework/pkg/addonfactory"
 	"open-cluster-management.io/addon-framework/pkg/addonmanager"
+	"open-cluster-management.io/addon-framework/pkg/agent"
 	"open-cluster-management.io/addon-framework/pkg/utils"
-	addonclient "open-cluster-management.io/api/client/addon/clientset/versioned"
+	addonv1beta1 "open-cluster-management.io/api/addon/v1beta1"
 	authv1beta1 "open-cluster-management.io/managed-serviceaccount/apis/authentication/v1beta1"
 	"open-cluster-management.io/managed-serviceaccount/pkg/addon/commoncontroller"
 	"open-cluster-management.io/managed-serviceaccount/pkg/addon/manager"
@@ -60,8 +64,14 @@ var (
 	setupLog = ctrl.Log.WithName("setup")
 )
 
+const (
+	deployModeDeployment    = "Deployment"
+	deployModeAddOnTemplate = "AddOnTemplate"
+)
+
 func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	utilruntime.Must(addonv1beta1.Install(scheme))
 	utilruntime.Must(authv1beta1.AddToScheme(scheme))
 	utilruntime.Must(cpv1alpha1.AddToScheme(scheme))
 	//+kubebuilder:scaffold:scheme
@@ -94,7 +104,7 @@ func (o *HubManagerOptions) AddFlags(flags *pflag.FlagSet) {
 	flags.BoolVar(&o.EnableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
-	flags.StringVar(&o.DeployMode, "deploy-mode", "Deployment",
+	flags.StringVar(&o.DeployMode, "deploy-mode", deployModeDeployment,
 		"Deployment mode for the manager. Valid values: 'Deployment' (default - runs addon manager and optional controllers), "+
 			"'AddOnTemplate' (runs only ClusterProfileCredSyncer controller without addon manager).")
 	flags.Var(
@@ -130,8 +140,11 @@ func NewHubManagerOptions() *HubManagerOptions {
 func (o *HubManagerOptions) Run() error {
 	logger := klog.Background()
 	klog.SetOutput(os.Stdout)
-	klog.InitFlags(flag.CommandLine)
 	ctrl.SetLogger(logger)
+
+	if err := o.validateDeployMode(); err != nil {
+		return err
+	}
 
 	err := features.FeatureGates.SetFromMap(o.FeatureGatesFlags)
 	if err != nil {
@@ -145,6 +158,7 @@ func (o *HubManagerOptions) Run() error {
 		HealthProbeBindAddress: o.ProbeAddr,
 		LeaderElection:         o.EnableLeaderElection,
 		LeaderElectionID:       "managed-serviceaccount-addon-manager",
+		Cache:                  managedServiceAccountCacheOptions(o.DeployMode),
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")
@@ -161,9 +175,8 @@ func (o *HubManagerOptions) Run() error {
 		os.Exit(1)
 	}
 
-	var addonManager addonmanager.AddonManager
-	if o.DeployMode != "AddOnTemplate" {
-		addonManager, err = addonmanager.New(mgr.GetConfig())
+	if o.DeployMode != deployModeAddOnTemplate {
+		addonManager, err := addonmanager.New(mgr.GetConfig())
 		if err != nil {
 			setupLog.Error(err, "unable to set up addon manager")
 			os.Exit(1)
@@ -172,12 +185,6 @@ func (o *HubManagerOptions) Run() error {
 		nativeClient, err := kubernetes.NewForConfig(mgr.GetConfig())
 		if err != nil {
 			setupLog.Error(err, "unable to instantiate kubernetes native client")
-			os.Exit(1)
-		}
-
-		addonClient, err := addonclient.NewForConfig(mgr.GetConfig())
-		if err != nil {
-			setupLog.Error(err, "unable to instantiate ocm addon client")
 			os.Exit(1)
 		}
 
@@ -201,13 +208,32 @@ func (o *HubManagerOptions) Run() error {
 			os.Exit(1)
 		}
 
-		deploymentConfigGetter := utils.NewAddOnDeploymentConfigGetter(addonClient)
+		if _, err := mgr.GetCache().GetInformer(context.Background(), &addonv1beta1.AddOnDeploymentConfig{}); err != nil {
+			setupLog.Error(err, "unable to initialize addon deployment config cache")
+			os.Exit(1)
+		}
+		deploymentConfigGetter := &cachedAddOnDeploymentConfigGetter{
+			reader: mgr.GetCache(),
+		}
+		agentInstallNamespaceFunc, err := manager.SetupAgentInstallNamespaceResolver(
+			context.Background(),
+			mgr.GetCache(),
+			utils.AgentInstallNamespaceFromDeploymentConfigFunc(deploymentConfigGetter),
+		)
+		if err != nil {
+			setupLog.Error(err, "unable to index managed cluster addon placement")
+			os.Exit(1)
+		}
 
 		agentFactory := addonfactory.NewAgentAddonFactory(common.AddonName, manager.FS, "manifests/charts/managed-serviceaccount-agent").
 			WithScheme(manager.NewAgentScheme()).
 			WithConfigGVRs(utils.AddOnDeploymentConfigGVR).
 			WithConfigCheckEnabledOption().
-			WithAgentInstallNamespace(utils.AgentInstallNamespaceFromDeploymentConfigFunc(deploymentConfigGetter)).
+			WithAgentHostedModeEnabledOption().
+			// Use lease health for every manager-driven agent, including an addon
+			// taken over from an AddOnTemplate installation.
+			WithAgentHealthProber(&agent.HealthProber{Type: agent.HealthProberTypeLease}).
+			WithAgentInstallNamespace(agentInstallNamespaceFunc).
 			WithGetValuesFuncs(
 				manager.GetDefaultValues(o.AddonAgentImageName, imagePullSecret, o.EnableNetworkPolicies),
 				addonfactory.GetAgentImageValues(
@@ -219,6 +245,7 @@ func (o *HubManagerOptions) Run() error {
 					deploymentConfigGetter,
 					addonfactory.ToAddOnDeploymentConfigValues,
 					manager.ToAddOnPrometheusValues,
+					manager.ValidateAddOnAgentVariables,
 				),
 			).
 			WithAgentRegistrationOption(manager.NewRegistrationOption(nativeClient)).
@@ -232,6 +259,11 @@ func (o *HubManagerOptions) Run() error {
 
 		if err := addonManager.AddAgent(agentAddOn); err != nil {
 			setupLog.Error(err, "unable to register addon agent")
+			os.Exit(1)
+		}
+
+		if err := mgr.Add(addonManagerRunnable{start: addonManager.Start}); err != nil {
+			setupLog.Error(err, "unable to register addon manager")
 			os.Exit(1)
 		}
 
@@ -262,18 +294,66 @@ func (o *HubManagerOptions) Run() error {
 	ctx, cancel := context.WithCancel(ctrl.SetupSignalHandler())
 	defer cancel()
 
-	if o.DeployMode != "AddOnTemplate" {
-		if err := addonManager.Start(ctx); err != nil {
-			setupLog.Error(err, "unable to start addon agent")
-			os.Exit(1)
-		}
-	}
-
 	if err := mgr.Start(ctx); err != nil {
 		setupLog.Error(err, "problem running manager")
 		os.Exit(1)
 	}
 	return nil
+}
+
+func managedServiceAccountCacheOptions(deployMode string) cache.Options {
+	if deployMode == deployModeAddOnTemplate {
+		return cache.Options{}
+	}
+
+	return cache.Options{ByObject: map[client.Object]cache.ByObject{
+		&addonv1beta1.ManagedClusterAddOn{}: {
+			Field: fields.OneTermEqualSelector("metadata.name", common.AddonName),
+		},
+	}}
+}
+
+// addonManagerRunnable preserves the addon manager's leader-elected placement
+// while making the requirement independent of controller-runtime defaults.
+type addonManagerRunnable struct {
+	start func(context.Context) error
+}
+
+func (r addonManagerRunnable) Start(ctx context.Context) error {
+	return r.start(ctx)
+}
+
+func (addonManagerRunnable) NeedLeaderElection() bool {
+	return true
+}
+
+// cachedAddOnDeploymentConfigGetter replaces the addon client backed
+// utils.NewAddOnDeploymentConfigGetter with a manager-cache read: the install
+// namespace uniqueness check resolves every peer addon's
+// deployment config per render, which must not become per-render hub API GETs.
+type cachedAddOnDeploymentConfigGetter struct {
+	reader client.Reader
+}
+
+func (g *cachedAddOnDeploymentConfigGetter) Get(
+	ctx context.Context,
+	namespace, name string,
+) (*addonv1beta1.AddOnDeploymentConfig, error) {
+	config := &addonv1beta1.AddOnDeploymentConfig{}
+	if err := g.reader.Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, config); err != nil {
+		return nil, err
+	}
+	return config, nil
+}
+
+func (o *HubManagerOptions) validateDeployMode() error {
+	switch o.DeployMode {
+	case deployModeDeployment, deployModeAddOnTemplate:
+		return nil
+	default:
+		return fmt.Errorf("unsupported --deploy-mode %q, must be %q or %q",
+			o.DeployMode, deployModeDeployment, deployModeAddOnTemplate)
+	}
 }
 
 func getAgentImagePullSecret(

--- a/cmd/manager/manager_test.go
+++ b/cmd/manager/manager_test.go
@@ -7,8 +7,52 @@ import (
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/client-go/kubernetes/fake"
+	ctrlmanager "sigs.k8s.io/controller-runtime/pkg/manager"
+
+	addonv1beta1 "open-cluster-management.io/api/addon/v1beta1"
+	"open-cluster-management.io/managed-serviceaccount/pkg/common"
 )
+
+var _ ctrlmanager.LeaderElectionRunnable = addonManagerRunnable{}
+
+func TestValidateDeployMode(t *testing.T) {
+	cases := []struct {
+		name          string
+		deployMode    string
+		expectedError string
+	}{
+		{
+			name:       "deployment",
+			deployMode: deployModeDeployment,
+		},
+		{
+			name:       "addon template",
+			deployMode: deployModeAddOnTemplate,
+		},
+		{
+			name:          "empty",
+			expectedError: `unsupported --deploy-mode "", must be "Deployment" or "AddOnTemplate"`,
+		},
+		{
+			name:          "unknown",
+			deployMode:    "AddOnTemplte",
+			expectedError: `unsupported --deploy-mode "AddOnTemplte", must be "Deployment" or "AddOnTemplate"`,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := (&HubManagerOptions{DeployMode: c.deployMode}).validateDeployMode()
+			if len(c.expectedError) > 0 {
+				assert.EqualError(t, err, c.expectedError)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
 
 func TestGetAgentImagePullSecret(t *testing.T) {
 	ctx := context.Background()
@@ -58,4 +102,37 @@ func TestGetAgentImagePullSecret(t *testing.T) {
 		assert.Nil(t, secret)
 		assert.ErrorContains(t, err, "incorrect type for agent image pull secret")
 	})
+}
+
+func TestManagedServiceAccountCacheOptions(t *testing.T) {
+	t.Run("deployment mode limits the managed cluster addon cache", func(t *testing.T) {
+		options := managedServiceAccountCacheOptions(deployModeDeployment)
+		var selector fields.Selector
+		for object, byObject := range options.ByObject {
+			if _, ok := object.(*addonv1beta1.ManagedClusterAddOn); ok {
+				selector = byObject.Field
+			}
+		}
+
+		if assert.NotNil(t, selector) {
+			assert.True(t, selector.Matches(fields.Set{"metadata.name": common.AddonName}))
+			assert.False(t, selector.Matches(fields.Set{"metadata.name": "another-addon"}))
+		}
+	})
+
+	t.Run("addon template mode does not require the managed cluster addon API", func(t *testing.T) {
+		assert.Empty(t, managedServiceAccountCacheOptions(deployModeAddOnTemplate).ByObject)
+	})
+}
+
+func TestAddonManagerRunnableRequiresLeaderElection(t *testing.T) {
+	started := false
+	runnable := addonManagerRunnable{start: func(context.Context) error {
+		started = true
+		return nil
+	}}
+
+	assert.True(t, runnable.NeedLeaderElection())
+	assert.NoError(t, runnable.Start(context.Background()))
+	assert.True(t, started)
 }

--- a/cmd/provisioner/provisioner.go
+++ b/cmd/provisioner/provisioner.go
@@ -1,0 +1,112 @@
+package provisioner
+
+import (
+	"context"
+	"os"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"k8s.io/client-go/kubernetes"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	_ "k8s.io/client-go/plugin/pkg/client/auth" //nolint:revive // required for auth plugins
+	"k8s.io/client-go/rest"
+	"k8s.io/klog/v2"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	"open-cluster-management.io/managed-serviceaccount/pkg/addon/provisioner"
+	"open-cluster-management.io/sdk-go/pkg/basecontroller/events"
+)
+
+type ProvisionerOptions struct {
+	SourceNamespace string
+	SourceSecret    string
+	TargetNamespace string
+	TargetSecret    string
+
+	ManagedServiceAccountNamespace string
+	ManagedServiceAccountName      string
+	HostingServiceAccountName      string
+	TokenExpirationSeconds         int64
+	RefreshBefore                  time.Duration
+	SyncInterval                   time.Duration
+}
+
+func NewProvisioner() *cobra.Command {
+	opts := NewProvisionerOptions()
+
+	cmd := &cobra.Command{
+		Use:   "managed-kubeconfig-provisioner",
+		Short: "Provision a least-privilege managed cluster kubeconfig for an agent running on a hosting cluster",
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := opts.Run(ctrl.SetupSignalHandler()); err != nil {
+				klog.Fatal(err)
+			}
+		},
+	}
+
+	opts.AddFlags(cmd.Flags())
+	return cmd
+}
+
+func NewProvisionerOptions() *ProvisionerOptions {
+	return &ProvisionerOptions{}
+}
+
+func (o *ProvisionerOptions) AddFlags(flags *pflag.FlagSet) {
+	flags.StringVar(&o.SourceNamespace, "source-namespace", "", "The namespace containing the external managed kubeconfig secret.")
+	flags.StringVar(&o.SourceSecret, "source-secret", provisioner.DefaultExternalManagedKubeConfigSecret, "The external managed kubeconfig secret name.")
+	flags.StringVar(&o.TargetNamespace, "target-namespace", "", "The addon install namespace where the managed kubeconfig secret is stored.")
+	flags.StringVar(&o.TargetSecret, "target-secret", "", "The managed kubeconfig secret name generated for the hosted addon agent.")
+	flags.StringVar(&o.ManagedServiceAccountNamespace, "managed-serviceaccount-namespace", "", "The managed cluster namespace containing the agent service account. Defaults to --target-namespace.")
+	flags.StringVar(&o.ManagedServiceAccountName, "managed-serviceaccount-name", provisioner.DefaultManagedServiceAccountName, "The managed cluster service account used by the agent.")
+	flags.StringVar(&o.HostingServiceAccountName, "hosting-service-account-name", provisioner.DefaultHostingServiceAccountName, "The hosting cluster service account that owns generated secrets.")
+	flags.Int64Var(&o.TokenExpirationSeconds, "token-expiration-seconds", provisioner.DefaultTokenExpirationSeconds, "Requested TokenRequest expiration seconds.")
+	flags.DurationVar(&o.RefreshBefore, "refresh-before", provisioner.DefaultRefreshBefore, "Refresh the generated kubeconfig when the token expires within this duration.")
+	flags.DurationVar(&o.SyncInterval, "sync-interval", provisioner.DefaultSyncInterval, "Maximum interval between generated kubeconfig reconciles; token expiration may trigger an earlier reconcile.")
+}
+
+func (o *ProvisionerOptions) Run(ctx context.Context) error {
+	logger := klog.Background()
+	klog.SetOutput(os.Stdout)
+	ctrl.SetLogger(logger)
+
+	cfg, err := rest.InClusterConfig()
+	if err != nil {
+		return errors.Wrapf(err, "failed to load hosting cluster in-cluster config")
+	}
+	cfg.Timeout = provisioner.DefaultRequestTimeout
+	hostingClient, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		return errors.Wrapf(err, "failed to build hosting cluster client")
+	}
+	eventRecorder, err := events.NewEventRecorder(
+		ctx,
+		clientgoscheme.Scheme,
+		hostingClient.EventsV1(),
+		"managed-kubeconfig-provisioner",
+	)
+	if err != nil {
+		return errors.Wrapf(err, "failed to create event recorder")
+	}
+
+	p := &provisioner.Provisioner{
+		HostingClient:                  hostingClient,
+		EventRecorder:                  eventRecorder,
+		SourceNamespace:                o.SourceNamespace,
+		SourceSecret:                   o.SourceSecret,
+		TargetNamespace:                o.TargetNamespace,
+		TargetSecret:                   o.TargetSecret,
+		ManagedServiceAccountNamespace: o.ManagedServiceAccountNamespace,
+		ManagedServiceAccountName:      o.ManagedServiceAccountName,
+		HostingServiceAccountName:      o.HostingServiceAccountName,
+		TokenExpirationSeconds:         o.TokenExpirationSeconds,
+		RefreshBefore:                  o.RefreshBefore,
+		SyncInterval:                   o.SyncInterval,
+	}
+	if err := p.Complete(); err != nil {
+		return err
+	}
+	return p.Start(ctx)
+}

--- a/e2e/cleanup/cleanup.go
+++ b/e2e/cleanup/cleanup.go
@@ -1,0 +1,211 @@
+package cleanup
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2" //nolint:revive,staticcheck // idiomatic ginkgo usage
+	. "github.com/onsi/gomega"    //nolint:revive,staticcheck // idiomatic gomega usage
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	addonv1beta1 "open-cluster-management.io/api/addon/v1beta1"
+	workv1 "open-cluster-management.io/api/work/v1"
+	"open-cluster-management.io/managed-serviceaccount/e2e/framework"
+	"open-cluster-management.io/managed-serviceaccount/pkg/addon/provisioner"
+	"open-cluster-management.io/managed-serviceaccount/pkg/common"
+)
+
+const (
+	cleanupTestBasename = "cleanup"
+	cleanupWaitTimeout  = 5 * time.Minute
+	cleanupPollInterval = 2 * time.Second
+
+	agentDeploymentName       = "managed-serviceaccount-addon-agent"
+	provisionerDeploymentName = "managed-serviceaccount-kubeconfig-provisioner"
+)
+
+var _ = Describe("Addon Cleanup Test", Label("cleanup"), func() {
+	f := framework.NewE2EFramework(cleanupTestBasename)
+
+	It("removes addon resources when the ManagedClusterAddOn is deleted", func(ctx SpecContext) {
+		hubClient := f.HubRuntimeClient()
+		addonKey := types.NamespacedName{
+			Namespace: f.TestClusterName(),
+			Name:      common.AddonName,
+		}
+		addon := &addonv1beta1.ManagedClusterAddOn{}
+		Expect(hubClient.Get(ctx, addonKey, addon)).To(Succeed())
+		Expect(addon.Status.Namespace).NotTo(BeEmpty(), "ManagedClusterAddOn status.namespace must be set before cleanup")
+		installNamespace := addon.Status.Namespace
+
+		verifyManifestWorksExist(ctx, f, hubClient)
+		verifyCleanupPreconditions(ctx, f, installNamespace)
+		if f.IsHostedMode() {
+			verifyHostedCleanupPreconditions(ctx, f, installNamespace)
+		}
+
+		disableAutomaticInstallation(ctx, hubClient)
+
+		By("Deleting the ManagedClusterAddOn")
+		Expect(hubClient.Delete(ctx, addon)).To(Succeed())
+		expectObjectDeleted(ctx, hubClient, addonKey, &addonv1beta1.ManagedClusterAddOn{})
+		expectManifestWorksDeleted(ctx, f, hubClient)
+
+		expectAddonResourcesDeleted(ctx, f, installNamespace)
+		if f.IsHostedMode() {
+			expectHostedResourcesDeleted(ctx, f, installNamespace)
+		}
+	})
+})
+
+// addonManifestWorkSelectors maps each hub namespace holding addon ManifestWorks
+// to the labels that select them.
+func addonManifestWorkSelectors(f framework.Framework) map[string]client.MatchingLabels {
+	selectors := map[string]client.MatchingLabels{
+		f.TestClusterName(): {addonv1beta1.AddonLabelKey: common.AddonName},
+	}
+	if f.IsHostedMode() {
+		selectors[f.HostingClusterName()] = client.MatchingLabels{
+			addonv1beta1.AddonLabelKey:          common.AddonName,
+			addonv1beta1.AddonNamespaceLabelKey: f.TestClusterName(),
+		}
+	}
+	return selectors
+}
+
+func verifyManifestWorksExist(ctx context.Context, f framework.Framework, hubClient client.Client) {
+	By("Verifying addon ManifestWorks exist before cleanup")
+	for namespace, labels := range addonManifestWorkSelectors(f) {
+		works := &workv1.ManifestWorkList{}
+		Expect(hubClient.List(ctx, works, client.InNamespace(namespace), labels)).To(Succeed())
+		Expect(works.Items).NotTo(BeEmpty(),
+			"expected addon ManifestWorks in namespace %s with labels %v", namespace, labels)
+	}
+}
+
+func expectManifestWorksDeleted(ctx context.Context, f framework.Framework, hubClient client.Client) {
+	By("Waiting for addon ManifestWorks to be deleted")
+	for namespace, labels := range addonManifestWorkSelectors(f) {
+		Eventually(ctx, func() error {
+			works := &workv1.ManifestWorkList{}
+			if err := hubClient.List(ctx, works, client.InNamespace(namespace), labels); err != nil {
+				return err
+			}
+			if len(works.Items) != 0 {
+				return fmt.Errorf("%d ManifestWorks in namespace %s with labels %v still exist",
+					len(works.Items), namespace, labels)
+			}
+			return nil
+		}).WithTimeout(cleanupWaitTimeout).WithPolling(cleanupPollInterval).Should(Succeed())
+	}
+}
+
+func verifyCleanupPreconditions(ctx context.Context, f framework.Framework, installNamespace string) {
+	By("Verifying addon agent and managed-cluster identity exist before cleanup")
+	Expect(f.AgentRuntimeClient().Get(ctx, types.NamespacedName{
+		Namespace: installNamespace,
+		Name:      agentDeploymentName,
+	}, &appsv1.Deployment{})).To(Succeed())
+	Expect(f.SpokeRuntimeClient().Get(ctx, types.NamespacedName{
+		Namespace: installNamespace,
+		Name:      provisioner.DefaultManagedServiceAccountName,
+	}, &corev1.ServiceAccount{})).To(Succeed())
+}
+
+func verifyHostedCleanupPreconditions(ctx context.Context, f framework.Framework, installNamespace string) {
+	By("Verifying hosted addon placement and ownership before cleanup")
+	Expect(installNamespace).To(Equal(f.HostedInstallNamespace()))
+
+	agentClient := f.AgentRuntimeClient()
+	spokeClient := f.SpokeRuntimeClient()
+	spokeNativeClient := f.SpokeNativeClient()
+	Expect(agentClient.Get(ctx, types.NamespacedName{
+		Namespace: installNamespace,
+		Name:      provisionerDeploymentName,
+	}, &appsv1.Deployment{})).To(Succeed())
+	Expect(agentClient.Get(ctx, types.NamespacedName{Name: installNamespace}, &corev1.Namespace{})).To(Succeed())
+	Expect(spokeClient.Get(ctx, types.NamespacedName{Name: installNamespace}, &corev1.Namespace{})).To(Succeed())
+
+	selector := "addon-agent in (managed-serviceaccount,managed-serviceaccount-kubeconfig-provisioner)"
+	spokeDeployments, err := spokeNativeClient.AppsV1().Deployments("").List(
+		ctx, metav1.ListOptions{LabelSelector: selector})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(spokeDeployments.Items).To(BeEmpty(), "hosted addon deployments must not run on the managed cluster")
+	spokePods, err := spokeNativeClient.CoreV1().Pods("").List(
+		ctx, metav1.ListOptions{LabelSelector: selector})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(spokePods.Items).To(BeEmpty(), "hosted addon pods must not run on the managed cluster")
+
+	provisionerServiceAccount := &corev1.ServiceAccount{}
+	Expect(agentClient.Get(ctx, types.NamespacedName{
+		Namespace: installNamespace,
+		Name:      provisioner.DefaultHostingServiceAccountName,
+	}, provisionerServiceAccount)).To(Succeed())
+
+	managedKubeConfigSecretName := common.AddonName + "-managed-kubeconfig"
+	managedKubeConfigSecret := &corev1.Secret{}
+	Expect(agentClient.Get(ctx, types.NamespacedName{
+		Namespace: installNamespace,
+		Name:      managedKubeConfigSecretName,
+	}, managedKubeConfigSecret)).To(Succeed())
+	Expect(metav1.IsControlledBy(managedKubeConfigSecret, provisionerServiceAccount)).To(BeTrue(),
+		"Secret %s/%s must be controlled by ServiceAccount %s",
+		installNamespace, managedKubeConfigSecretName, provisionerServiceAccount.Name)
+}
+
+func disableAutomaticInstallation(ctx context.Context, hubClient client.Client) {
+	By("Disabling automatic addon installation before deletion")
+	Eventually(ctx, func() error {
+		clusterManagementAddon := &addonv1beta1.ClusterManagementAddOn{}
+		if err := hubClient.Get(ctx, types.NamespacedName{Name: common.AddonName}, clusterManagementAddon); err != nil {
+			return err
+		}
+		if clusterManagementAddon.Spec.InstallStrategy.Type == addonv1beta1.AddonInstallStrategyManual &&
+			len(clusterManagementAddon.Spec.InstallStrategy.Placements) == 0 {
+			return nil
+		}
+		clusterManagementAddon.Spec.InstallStrategy = addonv1beta1.InstallStrategy{
+			Type: addonv1beta1.AddonInstallStrategyManual,
+		}
+		return hubClient.Update(ctx, clusterManagementAddon)
+	}).WithTimeout(cleanupWaitTimeout).WithPolling(cleanupPollInterval).Should(Succeed())
+}
+
+func expectAddonResourcesDeleted(ctx context.Context, f framework.Framework, installNamespace string) {
+	By("Waiting for addon agent and managed-cluster identity to be deleted")
+	expectObjectDeleted(ctx, f.AgentRuntimeClient(), types.NamespacedName{
+		Namespace: installNamespace,
+		Name:      agentDeploymentName,
+	}, &appsv1.Deployment{})
+	expectObjectDeleted(ctx, f.SpokeRuntimeClient(), types.NamespacedName{
+		Namespace: installNamespace,
+		Name:      provisioner.DefaultManagedServiceAccountName,
+	}, &corev1.ServiceAccount{})
+}
+
+func expectHostedResourcesDeleted(ctx context.Context, f framework.Framework, installNamespace string) {
+	By("Waiting for hosted addon namespaces to be deleted")
+	expectObjectDeleted(ctx, f.AgentRuntimeClient(), types.NamespacedName{Name: installNamespace}, &corev1.Namespace{})
+	expectObjectDeleted(ctx, f.SpokeRuntimeClient(), types.NamespacedName{Name: installNamespace}, &corev1.Namespace{})
+}
+
+func expectObjectDeleted(ctx context.Context, c client.Client, key types.NamespacedName, object client.Object) {
+	Eventually(ctx, func() error {
+		err := c.Get(ctx, key, object)
+		switch {
+		case apierrors.IsNotFound(err):
+			return nil
+		case err != nil:
+			return err
+		default:
+			return fmt.Errorf("%T %s/%s still exists", object, key.Namespace, key.Name)
+		}
+	}).WithTimeout(cleanupWaitTimeout).WithPolling(cleanupPollInterval).Should(Succeed())
+}

--- a/e2e/cleanup/e2e_test.go
+++ b/e2e/cleanup/e2e_test.go
@@ -1,0 +1,21 @@
+package cleanup
+
+import (
+	"os"
+	"testing"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+
+	"open-cluster-management.io/managed-serviceaccount/e2e/framework"
+)
+
+func TestMain(m *testing.M) {
+	gomega.RegisterFailHandler(ginkgo.Fail)
+	framework.ParseFlags()
+	os.Exit(m.Run())
+}
+
+func TestE2E(t *testing.T) {
+	ginkgo.RunSpecs(t, "ManagedServiceAccount e2e suite -- cleanup tests")
+}

--- a/e2e/clusterprofile_creds/clusterprofile_creds.go
+++ b/e2e/clusterprofile_creds/clusterprofile_creds.go
@@ -811,6 +811,7 @@ var _ = Describe("ClusterProfile Credentials Sync and Plugin Test", Label("clust
 				cmd := exec.Command(pluginPath, "--managed-serviceaccount="+msaName1)
 				cmd.Stdin = nil
 				cmd.Env = append(os.Environ(),
+					"KUBECONFIG="+f.HubKubeConfigPath(),
 					"NAMESPACE="+clusterProfileNamespace,
 					"KUBERNETES_EXEC_INFO="+string(execCredJSON),
 				)
@@ -851,6 +852,7 @@ var _ = Describe("ClusterProfile Credentials Sync and Plugin Test", Label("clust
 				cmd := exec.Command(pluginPath, "--managed-serviceaccount=nonexistent")
 				cmd.Stdin = nil
 				cmd.Env = append(os.Environ(),
+					"KUBECONFIG="+f.HubKubeConfigPath(),
 					"NAMESPACE="+clusterProfileNamespace,
 					"KUBERNETES_EXEC_INFO="+string(execCredJSON),
 				)

--- a/e2e/framework/context.go
+++ b/e2e/framework/context.go
@@ -11,8 +11,14 @@ import (
 var e2eContext = &E2EContext{}
 
 type E2EContext struct {
-	HubKubeConfig string
-	TestCluster   string
+	HubKubeConfig                      string
+	SpokeKubeConfig                    string
+	AgentKubeConfig                    string
+	TestCluster                        string
+	ExternalManagedKubeConfigNamespace string
+	ExternalManagedKubeConfigSecret    string
+	HostingClusterName                 string
+	HostedInstallNamespace             string
 }
 
 func ParseFlags() {
@@ -27,10 +33,34 @@ func registerFlags() {
 		"hub-kubeconfig",
 		os.Getenv("KUBECONFIG"),
 		"Path to kubeconfig of the hub cluster.")
+	flag.StringVar(&e2eContext.SpokeKubeConfig,
+		"spoke-kubeconfig",
+		"",
+		"Path to kubeconfig of the managed/spoke cluster. Defaults to --hub-kubeconfig.")
+	flag.StringVar(&e2eContext.AgentKubeConfig,
+		"agent-kubeconfig",
+		"",
+		"Path to kubeconfig of the cluster where the addon agent deployment runs. Defaults to --spoke-kubeconfig.")
 	flag.StringVar(&e2eContext.TestCluster,
 		"test-cluster",
 		"",
 		"The target cluster to run the e2e suite.")
+	flag.StringVar(&e2eContext.ExternalManagedKubeConfigNamespace,
+		"external-managed-kubeconfig-namespace",
+		"",
+		"Namespace of the external managed kubeconfig secret used when the agent runs on a hosting cluster, propagated through AddOnDeploymentConfig when set.")
+	flag.StringVar(&e2eContext.ExternalManagedKubeConfigSecret,
+		"external-managed-kubeconfig-secret",
+		"",
+		"Name of the external managed kubeconfig secret used when the agent runs on a hosting cluster, propagated through AddOnDeploymentConfig when set.")
+	flag.StringVar(&e2eContext.HostingClusterName,
+		"hosting-cluster-name",
+		"",
+		"Name of the registered hosting cluster. When set, the suite ensures and annotates the managed-serviceaccount ManagedClusterAddOn for hosted placement.")
+	flag.StringVar(&e2eContext.HostedInstallNamespace,
+		"hosted-install-namespace",
+		"",
+		"Dedicated addon install namespace on the hosting cluster, required when --hosting-cluster-name is set.")
 }
 
 func defaultFlags() {
@@ -39,6 +69,12 @@ func defaultFlags() {
 		if len(home) > 0 {
 			e2eContext.HubKubeConfig = filepath.Join(home, ".kube", "config")
 		}
+	}
+	if len(e2eContext.SpokeKubeConfig) == 0 {
+		e2eContext.SpokeKubeConfig = e2eContext.HubKubeConfig
+	}
+	if len(e2eContext.AgentKubeConfig) == 0 {
+		e2eContext.AgentKubeConfig = e2eContext.SpokeKubeConfig
 	}
 }
 
@@ -49,4 +85,34 @@ func validateFlags() {
 	if len(e2eContext.TestCluster) == 0 {
 		klog.Fatalf("--test-cluster is required")
 	}
+	if len(e2eContext.HostingClusterName) != 0 {
+		if len(e2eContext.HostedInstallNamespace) == 0 {
+			klog.Fatalf("--hosted-install-namespace is required when --hosting-cluster-name is set")
+		}
+		if sameKubeConfigPath(e2eContext.HubKubeConfig, e2eContext.SpokeKubeConfig) {
+			klog.Fatalf("--hub-kubeconfig and --spoke-kubeconfig must point to different kubeconfigs for a hosted agent")
+		}
+		if sameKubeConfigPath(e2eContext.SpokeKubeConfig, e2eContext.AgentKubeConfig) {
+			klog.Fatalf("--spoke-kubeconfig and --agent-kubeconfig must point to different kubeconfigs for a hosted agent")
+		}
+	}
+}
+
+// sameKubeConfigPath reports whether two kubeconfig paths resolve to the same file.
+func sameKubeConfigPath(a, b string) bool {
+	return normalizeKubeConfigPath(a) == normalizeKubeConfigPath(b)
+}
+
+func normalizeKubeConfigPath(path string) string {
+	if len(path) == 0 {
+		return ""
+	}
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return filepath.Clean(path)
+	}
+	if resolved, err := filepath.EvalSymlinks(abs); err == nil {
+		return resolved
+	}
+	return abs
 }

--- a/e2e/framework/framework.go
+++ b/e2e/framework/framework.go
@@ -18,10 +18,23 @@ var RunID = rand.String(6)
 
 type Framework interface {
 	HubRESTConfig() *rest.Config
+	SpokeRESTConfig() *rest.Config
+	AgentRESTConfig() *rest.Config
+	HubKubeConfigPath() string
+	SpokeKubeConfigPath() string
 	TestClusterName() string
+	IsHostedMode() bool
+	ExternalManagedKubeConfigNamespace() string
+	ExternalManagedKubeConfigSecret() string
+	HostingClusterName() string
+	HostedInstallNamespace() string
 
 	HubNativeClient() kubernetes.Interface
 	HubRuntimeClient() client.Client
+	SpokeNativeClient() kubernetes.Interface
+	SpokeRuntimeClient() client.Client
+	AgentNativeClient() kubernetes.Interface
+	AgentRuntimeClient() client.Client
 }
 
 var _ Framework = &framework{}
@@ -31,31 +44,74 @@ type framework struct {
 	ctx      *E2EContext
 }
 
-func NewE2EFramework(basename string) Framework {
-	f := &framework{
+func newFramework(basename string) *framework {
+	return &framework{
 		basename: basename,
 		ctx:      e2eContext,
 	}
+}
+
+func NewE2EFramework(basename string) Framework {
+	f := newFramework(basename)
 	BeforeEach(f.BeforeEach)
-	AfterEach(f.AfterEach)
 	return f
 }
 
+// NewSuiteFramework builds a Framework for suite-level nodes such as BeforeSuite,
+// which must not register a per-spec BeforeEach.
+func NewSuiteFramework(basename string) Framework {
+	return newFramework(basename)
+}
+
 func (f *framework) HubRESTConfig() *rest.Config {
-	restConfig, err := clientcmd.BuildConfigFromFlags("", f.ctx.HubKubeConfig)
+	return f.restConfig(f.ctx.HubKubeConfig)
+}
+
+func (f *framework) SpokeRESTConfig() *rest.Config {
+	return f.restConfig(f.ctx.SpokeKubeConfig)
+}
+
+func (f *framework) AgentRESTConfig() *rest.Config {
+	return f.restConfig(f.ctx.AgentKubeConfig)
+}
+
+func (f *framework) restConfig(kubeconfig string) *rest.Config {
+	restConfig, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
 	Expect(err).NotTo(HaveOccurred())
 	return restConfig
 }
 
 func (f *framework) HubNativeClient() kubernetes.Interface {
-	cfg := f.HubRESTConfig()
+	return f.nativeClient(f.HubRESTConfig())
+}
+
+func (f *framework) HubRuntimeClient() client.Client {
+	return f.runtimeClient(f.HubRESTConfig())
+}
+
+func (f *framework) SpokeNativeClient() kubernetes.Interface {
+	return f.nativeClient(f.SpokeRESTConfig())
+}
+
+func (f *framework) SpokeRuntimeClient() client.Client {
+	return f.runtimeClient(f.SpokeRESTConfig())
+}
+
+func (f *framework) AgentNativeClient() kubernetes.Interface {
+	return f.nativeClient(f.AgentRESTConfig())
+}
+
+func (f *framework) AgentRuntimeClient() client.Client {
+	return f.runtimeClient(f.AgentRESTConfig())
+}
+
+func (f *framework) nativeClient(cfg *rest.Config) kubernetes.Interface {
 	nativeClient, err := kubernetes.NewForConfig(cfg)
 	Expect(err).NotTo(HaveOccurred())
 	return nativeClient
 }
 
-func (f *framework) HubRuntimeClient() client.Client {
-	cfg := f.HubRESTConfig()
+func (f *framework) runtimeClient(cfg *rest.Config) client.Client {
 	runtimeClient, err := client.New(cfg, client.Options{
 		Scheme: scheme,
 	})
@@ -67,10 +123,35 @@ func (f *framework) TestClusterName() string {
 	return f.ctx.TestCluster
 }
 
+func (f *framework) HubKubeConfigPath() string {
+	return f.ctx.HubKubeConfig
+}
+
+func (f *framework) SpokeKubeConfigPath() string {
+	return f.ctx.SpokeKubeConfig
+}
+
+func (f *framework) IsHostedMode() bool {
+	return len(f.ctx.HostingClusterName) != 0
+}
+
+func (f *framework) ExternalManagedKubeConfigNamespace() string {
+	return f.ctx.ExternalManagedKubeConfigNamespace
+}
+
+func (f *framework) ExternalManagedKubeConfigSecret() string {
+	return f.ctx.ExternalManagedKubeConfigSecret
+}
+
+func (f *framework) HostingClusterName() string {
+	return f.ctx.HostingClusterName
+}
+
+func (f *framework) HostedInstallNamespace() string {
+	return f.ctx.HostedInstallNamespace
+}
+
 func (f *framework) BeforeEach() {
 	logger := klogr.New() //nolint:staticcheck // textlogger not vendored, klogr works fine for e2e tests
 	ctrl.SetLogger(logger)
-}
-
-func (f *framework) AfterEach() {
 }

--- a/e2e/framework/scheme.go
+++ b/e2e/framework/scheme.go
@@ -8,6 +8,7 @@ import (
 
 	addonv1beta1 "open-cluster-management.io/api/addon/v1beta1"
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
+	workv1 "open-cluster-management.io/api/work/v1"
 	authv1beta1 "open-cluster-management.io/managed-serviceaccount/apis/authentication/v1beta1"
 )
 
@@ -16,6 +17,7 @@ var scheme = runtime.NewScheme()
 func init() {
 	utilruntime.Must(clusterv1.Install(scheme))
 	utilruntime.Must(addonv1beta1.Install(scheme))
+	utilruntime.Must(workv1.Install(scheme))
 	utilruntime.Must(k8sscheme.AddToScheme(scheme))
 	utilruntime.Must(authv1beta1.AddToScheme(scheme))
 	utilruntime.Must(cpv1alpha1.AddToScheme(scheme))

--- a/e2e/install/install.go
+++ b/e2e/install/install.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"maps"
+	"os"
 	"slices"
 	"time"
 
@@ -14,32 +15,86 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	addonv1beta1 "open-cluster-management.io/api/addon/v1beta1"
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
+	authv1beta1 "open-cluster-management.io/managed-serviceaccount/apis/authentication/v1beta1"
 	"open-cluster-management.io/managed-serviceaccount/e2e/framework"
+	"open-cluster-management.io/managed-serviceaccount/pkg/addon/provisioner"
 	"open-cluster-management.io/managed-serviceaccount/pkg/common"
 )
 
 const (
-	installTestBasename           = "install"
-	installWaitTimeout            = 2 * time.Minute
+	installTestBasename = "install"
+	installWaitTimeout  = 2 * time.Minute
+	// The first hosted rollout serializes addon registration, provisioner
+	// error backoff, and kubelet volume-mount retries, and it runs in a
+	// BeforeSuite where a timeout fails every spec; give it a larger budget.
+	hostedRolloutTimeout          = 5 * time.Minute
+	installPollInterval           = 2 * time.Second
 	agentDeploymentName           = "managed-serviceaccount-addon-agent"
+	provisionerDeploymentName     = "managed-serviceaccount-kubeconfig-provisioner"
+	managedKubeConfigSecretSuffix = "-managed-kubeconfig"
 	addonDeploymentConfigGroup    = "addon.open-cluster-management.io"
 	addonDeploymentConfigResource = "addondeploymentconfigs"
 	defaultAgentImage             = "quay.io/open-cluster-management/managed-serviceaccount:latest"
+	hostedAgentDeployConfigName   = "hosted-agent-config"
+	hostedProvisionerSyncInterval = "5s"
+	hostedTokenPropagationWindow  = 90 * time.Second
+	// The addon-framework lease updater waits at most 75 seconds between
+	// reconciles. Two full intervals prove the invalid managed credential gates
+	// lease creation instead of merely delaying it.
+	hostedLeaseAbsenceWindow = 150 * time.Second
 )
+
+// Seed the hosted agent prerequisites in a BeforeSuite so they run before any
+// spec regardless of Ginkgo randomization.
+var _ = BeforeSuite(func() {
+	f := framework.NewSuiteFramework(installTestBasename)
+	if !f.IsHostedMode() {
+		return
+	}
+	hostedRolloutStartedAt := time.Now()
+
+	By("Seed external managed kubeconfig secret for hosted agent")
+	seedExternalManagedKubeConfigSecret(f)
+
+	By("Ensure ManagedClusterAddOn places the agent on the hosting cluster")
+	ensureHostedManagedClusterAddOn(f)
+
+	By("Apply AddOnDeploymentConfig for the agent on the hosting cluster")
+	ensureHostedAddOnDeploymentConfig(f)
+
+	By("Wait for hosted addon rollout")
+	waitForHostedAddonRollout(f, hostedRolloutStartedAt)
+})
 
 var _ = Describe("Addon Installation Test", Label("install"),
 	func() {
 		f := framework.NewE2EFramework(installTestBasename)
 		It("Addon healthiness should work", func() {
 			waitManagedClusterAddonAvailable(f)
+		})
+
+		It("Hosted agent reloads its managed cluster token without restarting", func() {
+			if !f.IsHostedMode() {
+				Skip("tokenFile rotation is specific to hosted agent placement")
+			}
+			verifyHostedManagedTokenRotation(f)
+		})
+
+		It("Hosted addon health follows managed cluster reachability", func() {
+			if !f.IsHostedMode() {
+				Skip("managed cluster health gating is specific to hosted agent placement")
+			}
+			verifyHostedManagedClusterHealth(f)
 		})
 
 		It("Addon can be configured with AddOnDeploymentConfig", func() {
@@ -87,6 +142,10 @@ var _ = Describe("Addon Installation Test", Label("install"),
 							Tolerations:  tolerations,
 						},
 					}
+					if f.IsHostedMode() {
+						deployConfig.Spec.AgentInstallNamespace = f.HostedInstallNamespace()
+					}
+					appendManagedKubeConfigVariables(f, &deployConfig.Spec)
 					return nil
 				})
 				return err
@@ -174,6 +233,7 @@ var _ = Describe("Addon Installation Test", Label("install"),
 							Tolerations:  tolerations,
 						},
 					}
+					appendManagedKubeConfigVariables(f, &deployConfig.Spec)
 					return nil
 				})
 				return err
@@ -393,9 +453,13 @@ func restoreManagedClusterImageRegistriesAnnotation(c client.Client, clusterName
 	return c.Update(context.TODO(), clusterCopy)
 }
 
+func getDeployment(c kubernetes.Interface, namespace, name string) (*appsv1.Deployment, error) {
+	return c.AppsV1().Deployments(namespace).Get(
+		context.TODO(), name, metav1.GetOptions{})
+}
+
 func getAgentDeployment(f framework.Framework, namespace string) (*appsv1.Deployment, error) {
-	return f.HubNativeClient().AppsV1().Deployments(namespace).Get(
-		context.TODO(), agentDeploymentName, metav1.GetOptions{})
+	return getDeployment(f.AgentNativeClient(), namespace, agentDeploymentName)
 }
 
 func waitAgentDeploymentRolledOutInAddonNamespace(f framework.Framework, validate func(*appsv1.Deployment) error) {
@@ -468,4 +532,503 @@ func expectAgentPlacement(deploy *appsv1.Deployment, nodeSelector map[string]str
 		return fmt.Errorf("unexpected tolerations %v", deploy.Spec.Template.Spec.Tolerations)
 	}
 	return nil
+}
+
+func appendManagedKubeConfigVariables(
+	f framework.Framework,
+	spec *addonv1beta1.AddOnDeploymentConfigSpec,
+) {
+	if !f.IsHostedMode() {
+		return
+	}
+
+	spec.CustomizedVariables = append(spec.CustomizedVariables, addonv1beta1.CustomizedVariable{
+		Name:  "managedKubeConfigProvisionerSyncInterval",
+		Value: hostedProvisionerSyncInterval,
+	})
+	if namespace := f.ExternalManagedKubeConfigNamespace(); namespace != "" {
+		spec.CustomizedVariables = append(spec.CustomizedVariables, addonv1beta1.CustomizedVariable{
+			Name:  "externalManagedKubeConfigNamespace",
+			Value: namespace,
+		})
+	}
+	if secret := f.ExternalManagedKubeConfigSecret(); secret != "" {
+		spec.CustomizedVariables = append(spec.CustomizedVariables, addonv1beta1.CustomizedVariable{
+			Name:  "externalManagedKubeConfigSecret",
+			Value: secret,
+		})
+	}
+}
+
+func seedExternalManagedKubeConfigSecret(f framework.Framework) {
+	namespace := f.ExternalManagedKubeConfigNamespace()
+	secret := f.ExternalManagedKubeConfigSecret()
+	if namespace == "" {
+		namespace = f.TestClusterName()
+	}
+	if secret == "" {
+		secret = provisioner.DefaultExternalManagedKubeConfigSecret
+	}
+
+	kubeconfig, err := os.ReadFile(f.SpokeKubeConfigPath())
+	Expect(err).NotTo(HaveOccurred())
+
+	c := f.AgentRuntimeClient()
+
+	Eventually(func() error {
+		return ensureNamespace(context.TODO(), c, namespace)
+	}).WithTimeout(installWaitTimeout).WithPolling(installPollInterval).ShouldNot(HaveOccurred())
+
+	Eventually(func() error {
+		s := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: secret, Namespace: namespace}}
+		_, err := controllerutil.CreateOrUpdate(context.TODO(), c, s, func() error {
+			s.Type = corev1.SecretTypeOpaque
+			if s.Data == nil {
+				s.Data = map[string][]byte{}
+			}
+			s.Data[provisioner.KubeconfigSecretKey] = kubeconfig
+			return nil
+		})
+		return err
+	}).WithTimeout(installWaitTimeout).WithPolling(installPollInterval).ShouldNot(HaveOccurred())
+}
+
+func ensureNamespace(ctx context.Context, c client.Client, name string) error {
+	return client.IgnoreAlreadyExists(c.Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: name}}))
+}
+
+func ensureHostedManagedClusterAddOn(f framework.Framework) {
+	hostingClusterName := f.HostingClusterName()
+	installNamespace := f.HostedInstallNamespace()
+
+	c := f.HubRuntimeClient()
+	Eventually(func() error {
+		addon := &addonv1beta1.ManagedClusterAddOn{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      common.AddonName,
+				Namespace: f.TestClusterName(),
+			},
+		}
+		_, err := controllerutil.CreateOrUpdate(context.TODO(), c, addon, func() error {
+			if addon.Annotations == nil {
+				addon.Annotations = map[string]string{}
+			}
+			addon.Annotations[addonv1beta1.HostingClusterNameAnnotationKey] = hostingClusterName
+			addon.Annotations[addonv1beta1.InstallNamespaceAnnotation] = installNamespace
+			return nil
+		})
+		return err
+	}).WithTimeout(installWaitTimeout).WithPolling(installPollInterval).ShouldNot(HaveOccurred())
+}
+
+func waitForHostedAddonInstallNamespace(f framework.Framework, timeout time.Duration) {
+	c := f.HubRuntimeClient()
+	Eventually(func() error {
+		addon, err := getManagedClusterAddon(c, f.TestClusterName())
+		if err != nil {
+			return err
+		}
+		if addon.Status.Namespace != f.HostedInstallNamespace() {
+			return fmt.Errorf("addon install namespace is %q, want %q",
+				addon.Status.Namespace, f.HostedInstallNamespace())
+		}
+		return nil
+	}).WithTimeout(timeout).WithPolling(installPollInterval).ShouldNot(HaveOccurred())
+}
+
+func ensureHostedAddOnDeploymentConfig(f framework.Framework) {
+	c := f.HubRuntimeClient()
+	Eventually(func() error {
+		deployConfig := &addonv1beta1.AddOnDeploymentConfig{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      hostedAgentDeployConfigName,
+				Namespace: f.TestClusterName(),
+			},
+		}
+		_, err := controllerutil.CreateOrUpdate(context.TODO(), c, deployConfig, func() error {
+			deployConfig.Spec = addonv1beta1.AddOnDeploymentConfigSpec{
+				AgentInstallNamespace: f.HostedInstallNamespace(),
+			}
+			appendManagedKubeConfigVariables(f, &deployConfig.Spec)
+			return nil
+		})
+		return err
+	}).WithTimeout(installWaitTimeout).WithPolling(installPollInterval).ShouldNot(HaveOccurred())
+
+	Eventually(func() error {
+		addon, err := getManagedClusterAddon(c, f.TestClusterName())
+		if err != nil {
+			return err
+		}
+
+		desired := addonDeploymentConfigReference(f.TestClusterName(), hostedAgentDeployConfigName)
+		for _, cfg := range addon.Spec.Configs {
+			if cfg == desired {
+				return nil
+			}
+		}
+		addon.Spec.Configs = append(addon.Spec.Configs, desired)
+		return c.Update(context.TODO(), addon)
+	}).WithTimeout(installWaitTimeout).WithPolling(installPollInterval).ShouldNot(HaveOccurred())
+}
+
+func waitForHostedAddonRollout(f framework.Framework, rolloutStartedAt time.Time) {
+	waitForHostedAddonInstallNamespace(f, hostedRolloutTimeout)
+	addonInstallNamespace := f.HostedInstallNamespace()
+	waitForHostedProvisionerSyncInterval(f, addonInstallNamespace)
+	waitDeploymentRolledOut(f, addonInstallNamespace, provisionerDeploymentName, hostedRolloutTimeout)
+	waitDeploymentRolledOut(f, addonInstallNamespace, agentDeploymentName, hostedRolloutTimeout)
+	assertNoSpokeAgentWorkloads(f)
+
+	waitForManagedAddonLease(f, addonInstallNamespace, rolloutStartedAt)
+	waitManagedClusterAddonAvailable(f)
+}
+
+// waitForHostedProvisionerSyncInterval waits until the AddOnDeploymentConfig
+// applied by the suite reaches the rendered provisioner arguments. Rollout
+// completion alone does not prove that: the install namespace also resolves
+// through the ManagedClusterAddOn annotation, so a provisioner rendered before
+// the config landed still rolls out, with the default sync interval.
+func waitForHostedProvisionerSyncInterval(f framework.Framework, namespace string) {
+	agentClient := f.AgentNativeClient()
+	expectedArg := "--sync-interval=" + hostedProvisionerSyncInterval
+	Eventually(func() error {
+		deploy, err := getDeployment(agentClient, namespace, provisionerDeploymentName)
+		if err != nil {
+			return err
+		}
+		args := deploy.Spec.Template.Spec.Containers[0].Args
+		for _, arg := range args {
+			if arg == expectedArg {
+				return nil
+			}
+		}
+		return fmt.Errorf("provisioner args %v do not yet include %q", args, expectedArg)
+	}).WithTimeout(hostedRolloutTimeout).WithPolling(installPollInterval).Should(Succeed())
+}
+
+func waitDeploymentRolledOut(f framework.Framework, namespace, name string, timeout time.Duration) {
+	agentClient := f.AgentNativeClient()
+	Eventually(func() error {
+		deploy, err := getDeployment(agentClient, namespace, name)
+		if err != nil {
+			return err
+		}
+		return agentDeploymentRolledOut(deploy)
+	}).WithTimeout(timeout).WithPolling(installPollInterval).Should(Succeed())
+}
+
+func assertNoSpokeAgentWorkloads(f framework.Framework) {
+	spokeClient := f.SpokeNativeClient()
+	listOptions := metav1.ListOptions{
+		LabelSelector: "addon-agent in (managed-serviceaccount,managed-serviceaccount-kubeconfig-provisioner)",
+	}
+	Consistently(func() error {
+		deployments, err := spokeClient.AppsV1().Deployments("").List(context.TODO(), listOptions)
+		if err != nil {
+			return err
+		}
+		pods, err := spokeClient.CoreV1().Pods("").List(context.TODO(), listOptions)
+		if err != nil {
+			return err
+		}
+
+		names := make([]string, 0, len(deployments.Items)+len(pods.Items))
+		for _, deploy := range deployments.Items {
+			names = append(names, "deployment "+deploy.Namespace+"/"+deploy.Name)
+		}
+		for _, pod := range pods.Items {
+			names = append(names, "pod "+pod.Namespace+"/"+pod.Name)
+		}
+		if len(names) != 0 {
+			return fmt.Errorf("hosted addon workloads unexpectedly present on managed cluster: %v", names)
+		}
+		return nil
+	}).WithTimeout(30 * time.Second).WithPolling(installPollInterval).Should(Succeed())
+}
+
+func verifyHostedManagedTokenRotation(f framework.Framework) {
+	ctx := context.TODO()
+	waitForHostedAddonInstallNamespace(f, installWaitTimeout)
+	installNamespace := f.HostedInstallNamespace()
+	hubClient := f.HubRuntimeClient()
+	hostingClient := f.AgentNativeClient()
+	managedClient := f.SpokeNativeClient()
+
+	agentPod := waitForHostedAgentPod(hostingClient, installNamespace)
+	agentPodName := agentPod.Name
+	agentPodUID := agentPod.UID
+
+	managedServiceAccount, err := managedClient.CoreV1().ServiceAccounts(installNamespace).Get(
+		ctx, provisioner.DefaultManagedServiceAccountName, metav1.GetOptions{})
+	Expect(err).NotTo(HaveOccurred())
+	previousServiceAccountUID := managedServiceAccount.UID
+
+	managedSecretName := common.AddonName + managedKubeConfigSecretSuffix
+	managedSecret, err := hostingClient.CoreV1().Secrets(installNamespace).Get(
+		ctx, managedSecretName, metav1.GetOptions{})
+	Expect(err).NotTo(HaveOccurred())
+	previousToken := slices.Clone(managedSecret.Data[corev1.ServiceAccountTokenKey])
+	Expect(previousToken).NotTo(BeEmpty())
+
+	By("Recreate the managed-cluster service account backing the hosted agent token")
+	Expect(managedClient.CoreV1().ServiceAccounts(installNamespace).Delete(
+		ctx,
+		provisioner.DefaultManagedServiceAccountName,
+		metav1.DeleteOptions{Preconditions: &metav1.Preconditions{UID: &previousServiceAccountUID}},
+	)).To(Succeed())
+
+	var currentServiceAccountUID types.UID
+	Eventually(func() error {
+		serviceAccount, err := managedClient.CoreV1().ServiceAccounts(installNamespace).Create(
+			ctx,
+			&corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{
+				Name:      provisioner.DefaultManagedServiceAccountName,
+				Namespace: installNamespace,
+			}},
+			metav1.CreateOptions{},
+		)
+		if apierrors.IsAlreadyExists(err) {
+			serviceAccount, err = managedClient.CoreV1().ServiceAccounts(installNamespace).Get(
+				ctx, provisioner.DefaultManagedServiceAccountName, metav1.GetOptions{})
+		}
+		if err != nil {
+			return err
+		}
+		if serviceAccount.UID == previousServiceAccountUID {
+			return fmt.Errorf("managed serviceaccount %s/%s still has UID %s",
+				installNamespace, provisioner.DefaultManagedServiceAccountName, previousServiceAccountUID)
+		}
+		currentServiceAccountUID = serviceAccount.UID
+		return nil
+	}).WithTimeout(installWaitTimeout).WithPolling(installPollInterval).Should(Succeed())
+
+	Eventually(func() error {
+		secret, err := hostingClient.CoreV1().Secrets(installNamespace).Get(
+			ctx, managedSecretName, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		if secret.Annotations[provisioner.ManagedServiceAccountUIDAnnotation] != string(currentServiceAccountUID) {
+			return fmt.Errorf("managed kubeconfig secret still references serviceaccount UID %q",
+				secret.Annotations[provisioner.ManagedServiceAccountUIDAnnotation])
+		}
+		if slices.Equal(secret.Data[corev1.ServiceAccountTokenKey], previousToken) {
+			return fmt.Errorf("managed kubeconfig token has not rotated")
+		}
+		return nil
+	}).WithTimeout(installWaitTimeout).WithPolling(installPollInterval).Should(Succeed())
+
+	By("Reconcile a new ManagedServiceAccount through the unchanged hosted agent pod")
+	probeName := "e2e-hosted-tokenfile-" + framework.RunID
+	probe := &authv1beta1.ManagedServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{Name: probeName, Namespace: f.TestClusterName()},
+		Spec: authv1beta1.ManagedServiceAccountSpec{
+			Rotation: authv1beta1.ManagedServiceAccountRotation{
+				Validity: metav1.Duration{Duration: 30 * time.Minute},
+			},
+		},
+	}
+	Expect(hubClient.Create(ctx, probe)).To(Succeed())
+	DeferCleanup(func() {
+		Expect(client.IgnoreNotFound(hubClient.Delete(context.TODO(), probe))).To(Succeed())
+	})
+
+	Eventually(func() error {
+		_, err := managedClient.CoreV1().ServiceAccounts(installNamespace).Get(
+			ctx, probeName, metav1.GetOptions{})
+		return err
+	}).WithTimeout(3 * time.Minute).WithPolling(installPollInterval).Should(Succeed())
+
+	agentPod, err = hostingClient.CoreV1().Pods(installNamespace).Get(ctx, agentPodName, metav1.GetOptions{})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(agentPod.UID).To(Equal(agentPodUID), "hosted agent should reload tokenFile without restarting")
+}
+
+func verifyHostedManagedClusterHealth(f framework.Framework) {
+	ctx := context.TODO()
+	waitForHostedAddonInstallNamespace(f, installWaitTimeout)
+	installNamespace := f.HostedInstallNamespace()
+	hostingClient := f.AgentNativeClient()
+	hubClient := f.HubRuntimeClient()
+	agentPodUID := waitForHostedAgentPod(hostingClient, installNamespace).UID
+	managedSecretName := common.AddonName + managedKubeConfigSecretSuffix
+
+	managedSecret, err := hostingClient.CoreV1().Secrets(installNamespace).Get(
+		ctx, managedSecretName, metav1.GetOptions{})
+	Expect(err).NotTo(HaveOccurred())
+	originalToken := slices.Clone(managedSecret.Data[corev1.ServiceAccountTokenKey])
+	Expect(originalToken).NotTo(BeEmpty())
+
+	restoreToken := func() {
+		setManagedKubeConfigToken(hostingClient, installNamespace, managedSecretName, originalToken)
+	}
+	DeferCleanup(func() {
+		restoreToken()
+		Eventually(func() error {
+			lease, err := hostingClient.CoordinationV1().Leases(installNamespace).Get(
+				context.TODO(), common.AddonName, metav1.GetOptions{})
+			if err != nil {
+				return err
+			}
+			if lease.Spec.RenewTime == nil {
+				return fmt.Errorf("restored lease has no renew time")
+			}
+			return nil
+		}).WithTimeout(hostedRolloutTimeout).WithPolling(installPollInterval).Should(Succeed())
+		waitManagedClusterAddonAvailable(f)
+	})
+
+	By("Invalidate the managed cluster token mounted by the hosted agent")
+	setManagedKubeConfigToken(
+		hostingClient,
+		installNamespace,
+		managedSecretName,
+		[]byte("invalid-e2e-token-"+framework.RunID),
+	)
+	waitForHostedAgentToObserveInvalidToken(hostingClient, installNamespace)
+
+	By("Delete the stale lease to surface stopped renewal without waiting for the OCM lease grace period")
+	staleLease, err := hostingClient.CoordinationV1().Leases(installNamespace).Get(
+		ctx, common.AddonName, metav1.GetOptions{})
+	Expect(err).NotTo(HaveOccurred())
+	staleLeaseUID := staleLease.UID
+	Expect(hostingClient.CoordinationV1().Leases(installNamespace).Delete(
+		ctx,
+		common.AddonName,
+		metav1.DeleteOptions{Preconditions: &metav1.Preconditions{UID: &staleLeaseUID}},
+	)).To(Succeed())
+
+	Consistently(func() error {
+		_, err := hostingClient.CoordinationV1().Leases(installNamespace).Get(
+			ctx, common.AddonName, metav1.GetOptions{})
+		switch {
+		case apierrors.IsNotFound(err):
+			return nil
+		case err != nil:
+			return err
+		default:
+			return fmt.Errorf("managed addon lease was recreated while the managed token was invalid")
+		}
+	}).WithTimeout(hostedLeaseAbsenceWindow).WithPolling(installPollInterval).Should(Succeed())
+
+	Eventually(func() error {
+		addon, err := getManagedClusterAddon(hubClient, f.TestClusterName())
+		if err != nil {
+			return err
+		}
+		available := meta.FindStatusCondition(addon.Status.Conditions, addonv1beta1.ManagedClusterAddOnConditionAvailable)
+		if available == nil || available.Status != metav1.ConditionUnknown ||
+			available.Reason != addonv1beta1.AddonAvailableReasonLeaseLeaseNotFound {
+			return fmt.Errorf("expected missing lease to make addon availability unknown, got %v", available)
+		}
+		return nil
+	}).WithTimeout(hostedRolloutTimeout).WithPolling(installPollInterval).Should(Succeed())
+
+	By("Restore the managed token and verify lease health recovers without restarting the agent")
+	restoreToken()
+	Eventually(func() error {
+		lease, err := hostingClient.CoordinationV1().Leases(installNamespace).Get(
+			ctx, common.AddonName, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		if lease.UID == staleLeaseUID {
+			return fmt.Errorf("managed addon lease has not been recreated")
+		}
+		return nil
+	}).WithTimeout(hostedRolloutTimeout).WithPolling(installPollInterval).Should(Succeed())
+	waitManagedClusterAddonAvailable(f)
+	Expect(waitForHostedAgentPod(hostingClient, installNamespace).UID).To(Equal(agentPodUID),
+		"hosted agent should recover managed API health without restarting")
+}
+
+func waitForHostedAgentPod(hostingClient kubernetes.Interface, namespace string) *corev1.Pod {
+	var agentPod *corev1.Pod
+	Eventually(func() error {
+		pods, err := hostingClient.CoreV1().Pods(namespace).List(
+			context.TODO(), metav1.ListOptions{LabelSelector: "addon-agent=managed-serviceaccount"})
+		if err != nil {
+			return err
+		}
+		if len(pods.Items) != 1 {
+			return fmt.Errorf("expected exactly one hosted agent pod, found %d", len(pods.Items))
+		}
+		agentPod = pods.Items[0].DeepCopy()
+		return nil
+	}).WithTimeout(installWaitTimeout).WithPolling(installPollInterval).Should(Succeed())
+	return agentPod
+}
+
+func setManagedKubeConfigToken(
+	hostingClient kubernetes.Interface,
+	namespace, secretName string,
+	token []byte,
+) {
+	Eventually(func() error {
+		secret, err := hostingClient.CoreV1().Secrets(namespace).Get(
+			context.TODO(), secretName, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		secret.Data[corev1.ServiceAccountTokenKey] = slices.Clone(token)
+		_, err = hostingClient.CoreV1().Secrets(namespace).Update(
+			context.TODO(), secret, metav1.UpdateOptions{})
+		return err
+	}).WithTimeout(installWaitTimeout).WithPolling(installPollInterval).Should(Succeed())
+}
+
+// waitForHostedAgentToObserveInvalidToken uses a stopped renewal only as a
+// readiness signal for Secret volume propagation. The caller separately
+// deletes the Lease and proves that the agent cannot recreate it.
+func waitForHostedAgentToObserveInvalidToken(hostingClient kubernetes.Interface, namespace string) {
+	var observedRenewTime time.Time
+	var unchangedSince time.Time
+	Eventually(func() error {
+		lease, err := hostingClient.CoordinationV1().Leases(namespace).Get(
+			context.TODO(), common.AddonName, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		if lease.Spec.RenewTime == nil {
+			return fmt.Errorf("lease %s/%s has no renew time", namespace, common.AddonName)
+		}
+		renewTime := lease.Spec.RenewTime.Time
+		if unchangedSince.IsZero() || !renewTime.Equal(observedRenewTime) {
+			observedRenewTime = renewTime
+			unchangedSince = time.Now()
+			return fmt.Errorf("lease renewal has not yet remained stopped for %s", hostedTokenPropagationWindow)
+		}
+		if stableFor := time.Since(unchangedSince); stableFor < hostedTokenPropagationWindow {
+			return fmt.Errorf("lease renewal has remained stopped for %s, want %s", stableFor, hostedTokenPropagationWindow)
+		}
+		return nil
+	}).WithTimeout(hostedRolloutTimeout).WithPolling(installPollInterval).Should(Succeed())
+}
+
+func waitForManagedAddonLease(f framework.Framework, namespace string, rolloutStartedAt time.Time) {
+	leaseClient := f.AgentNativeClient()
+	Eventually(func() error {
+		lease, err := leaseClient.CoordinationV1().Leases(namespace).Get(
+			context.TODO(), common.AddonName, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		if lease.Spec.RenewTime == nil {
+			return fmt.Errorf("lease %s/%s has no renew time", namespace, common.AddonName)
+		}
+		if lease.Spec.RenewTime.Time.Before(rolloutStartedAt) {
+			return fmt.Errorf("lease %s/%s has not been renewed during this rollout", namespace, common.AddonName)
+		}
+		if lease.Spec.LeaseDurationSeconds == nil || *lease.Spec.LeaseDurationSeconds <= 0 {
+			return fmt.Errorf("lease %s/%s has no valid duration", namespace, common.AddonName)
+		}
+		expiresAt := lease.Spec.RenewTime.Add(time.Duration(*lease.Spec.LeaseDurationSeconds) * time.Second)
+		if !expiresAt.After(time.Now()) {
+			return fmt.Errorf("lease %s/%s expired at %s", namespace, common.AddonName, expiresAt)
+		}
+		// The addon-framework lease updater does not set holderIdentity; a fresh,
+		// unexpired renewal is the active-agent signal for this lease.
+		return nil
+	}).WithTimeout(installWaitTimeout).WithPolling(installPollInterval).ShouldNot(HaveOccurred())
 }

--- a/e2e/token/token.go
+++ b/e2e/token/token.go
@@ -51,11 +51,9 @@ var _ = Describe("Token Test for Managed Service Account v1beta1",
 					Name:      common.AddonName,
 				}, addon)
 				Expect(err).NotTo(HaveOccurred())
-				sa := &corev1.ServiceAccount{}
-				err = f.HubRuntimeClient().Get(context.TODO(), types.NamespacedName{
-					Namespace: addon.Status.Namespace,
-					Name:      msa.Name,
-				}, sa)
+				_, err = f.SpokeNativeClient().CoreV1().
+					ServiceAccounts(addon.Status.Namespace).
+					Get(context.TODO(), msa.Name, metav1.GetOptions{})
 				if apierrors.IsNotFound(err) {
 					return false, nil
 				}
@@ -149,11 +147,9 @@ var _ = Describe("Token Test for Managed Service Account v1beta1",
 			}, secret)
 			Expect(err).NotTo(HaveOccurred())
 
-			serviceAccount := &corev1.ServiceAccount{}
-			err = f.HubRuntimeClient().Get(context.TODO(), types.NamespacedName{
-				Namespace: addon.Status.Namespace,
-				Name:      targetName,
-			}, serviceAccount)
+			_, err = f.SpokeNativeClient().CoreV1().
+				ServiceAccounts(addon.Status.Namespace).
+				Get(context.TODO(), targetName, metav1.GetOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Deleting ManagedServiceAccount", func() {
@@ -195,11 +191,9 @@ var _ = Describe("Token Test for Managed Service Account v1beta1",
 
 			//serviceaccount should be deleted
 			Eventually(func() error {
-				serviceAccount := &corev1.ServiceAccount{}
-				err = f.HubRuntimeClient().Get(context.TODO(), types.NamespacedName{
-					Namespace: addon.Status.Namespace,
-					Name:      targetName,
-				}, serviceAccount)
+				_, err = f.SpokeNativeClient().CoreV1().
+					ServiceAccounts(addon.Status.Namespace).
+					Get(context.TODO(), targetName, metav1.GetOptions{})
 				if err == nil {
 					return fmt.Errorf("serviceaccount %s/%s still exists", addon.Status.Namespace, targetName)
 				}
@@ -255,7 +249,9 @@ func validateToken(f framework.Framework, targetName string) {
 			Token: string(token),
 		},
 	}
-	err = f.HubRuntimeClient().Create(context.TODO(), tokenReview)
+	tokenReview, err = f.SpokeNativeClient().AuthenticationV1().
+		TokenReviews().
+		Create(context.TODO(), tokenReview, metav1.CreateOptions{})
 	Expect(err).NotTo(HaveOccurred())
 
 	Expect(tokenReview.Status.Authenticated).To(BeTrue())

--- a/go.mod
+++ b/go.mod
@@ -18,8 +18,10 @@ require (
 	k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2
 	open-cluster-management.io/addon-framework v1.3.0
 	open-cluster-management.io/api v1.3.1-0.20260709055002-403378b57558
+	open-cluster-management.io/sdk-go v1.3.0
 	sigs.k8s.io/cluster-inventory-api v0.1.3
 	sigs.k8s.io/controller-runtime v0.24.1
+	sigs.k8s.io/yaml v1.6.0
 )
 
 require (
@@ -98,9 +100,7 @@ require (
 	helm.sh/helm/v3 v3.19.4 // indirect
 	k8s.io/apiextensions-apiserver v0.36.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20260319004828-5883c5ee87b9 // indirect
-	open-cluster-management.io/sdk-go v1.3.0 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.2 // indirect
-	sigs.k8s.io/yaml v1.6.0 // indirect
 )

--- a/hack/e2e/dump.sh
+++ b/hack/e2e/dump.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+set -o nounset
+set -o pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+kubeconfig_dir=${KUBECONFIG_DIR:-"${repo_root}/_output/e2e/kubeconfigs"}
+hosting_cluster=${HOSTING_CLUSTER_NAME:-hosting}
+spoke_cluster=${SPOKE_CLUSTER_NAME:-spoke}
+hub_args=()
+
+if [[ -f "${kubeconfig_dir}/hub.kubeconfig" ]]; then
+	hub_args=(--kubeconfig="${kubeconfig_dir}/hub.kubeconfig")
+fi
+
+# The agent and the provisioner both carry an addon-agent label, so their
+# namespaces do not have to be known up front.
+dump_agent_logs() {
+	local namespace
+	for namespace in $(kubectl "$@" get pods -A -l addon-agent \
+		-o jsonpath='{range .items[*]}{.metadata.namespace}{"\n"}{end}' | sort -u); do
+		kubectl "$@" -n "${namespace}" \
+			logs -l addon-agent --all-containers --tail=-1 --prefix || true
+	done
+}
+
+kubectl "${hub_args[@]}" get clustermanagementaddon managed-serviceaccount -o yaml || true
+kubectl "${hub_args[@]}" get managedclusteraddon -A -o yaml || true
+kubectl "${hub_args[@]}" get addondeploymentconfig -A -o yaml || true
+kubectl "${hub_args[@]}" get manifestwork -A -o yaml || true
+kubectl "${hub_args[@]}" get deploy,pod,serviceaccount,role,rolebinding,lease -A -o wide || true
+kubectl "${hub_args[@]}" get events -A --sort-by=.lastTimestamp || true
+kubectl "${hub_args[@]}" -n open-cluster-management-addon \
+	logs deploy/managed-serviceaccount-addon-manager --all-containers --tail=-1 --prefix || true
+dump_agent_logs "${hub_args[@]}"
+
+for cluster in "${hosting_cluster}" "${spoke_cluster}"; do
+	kubeconfig="${kubeconfig_dir}/${cluster}.kubeconfig"
+	if [[ ! -f "${kubeconfig}" ]]; then
+		continue
+	fi
+
+	echo "=== ${cluster} resources ==="
+	kubectl --kubeconfig="${kubeconfig}" \
+		get deploy,pod,serviceaccount,role,rolebinding,secret,lease -A -o wide || true
+	kubectl --kubeconfig="${kubeconfig}" \
+		get events -A --sort-by=.lastTimestamp || true
+	dump_agent_logs --kubeconfig="${kubeconfig}"
+done

--- a/hack/e2e/setup-hosted.sh
+++ b/hack/e2e/setup-hosted.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+kubeconfig_dir=${KUBECONFIG_DIR:-"${repo_root}/_output/e2e/kubeconfigs"}
+hub_cluster=${HUB_CLUSTER_NAME:-chart-testing}
+hosting_cluster=${HOSTING_CLUSTER_NAME:-hosting}
+spoke_cluster=${SPOKE_CLUSTER_NAME:-spoke}
+image=${E2E_IMAGE:-quay.io/open-cluster-management/managed-serviceaccount:latest}
+
+mkdir -p "${kubeconfig_dir}"
+
+kind create cluster --name "${hosting_cluster}"
+kind create cluster --name "${spoke_cluster}"
+
+# Use kind-network IPs so the kubeconfigs work both on the runner and from
+# workloads in the other kind clusters without modifying the runner's hosts.
+write_kubeconfig() {
+	local cluster_name=$1
+	local output=$2
+	local control_plane_ip
+
+	kind get kubeconfig --name "${cluster_name}" --internal >"${output}"
+	control_plane_ip=$(docker inspect -f '{{(index .NetworkSettings.Networks "kind").IPAddress}}' \
+		"${cluster_name}-control-plane")
+	kubectl --kubeconfig="${output}" config set-cluster "kind-${cluster_name}" \
+		--server="https://${control_plane_ip}:6443"
+}
+
+write_kubeconfig "${hub_cluster}" "${kubeconfig_dir}/hub.kubeconfig"
+write_kubeconfig "${hosting_cluster}" "${kubeconfig_dir}/${hosting_cluster}.kubeconfig"
+write_kubeconfig "${spoke_cluster}" "${kubeconfig_dir}/${spoke_cluster}.kubeconfig"
+
+# The image was built by the preceding e2e phase, where the agent runs on the
+# managed cluster. The hub already has it; the hosting cluster needs it for the
+# hosted agent and kubeconfig provisioner.
+kind load docker-image "${image}" --name "${hosting_cluster}"
+
+export KUBECONFIG="${kubeconfig_dir}/hub.kubeconfig"
+
+# The hosted phase must not depend on the managed-cluster cleanup suite having
+# disabled automatic installation. Otherwise a failed first phase can race the
+# hosted setup by creating a Default-mode addon on the newly joined clusters.
+kubectl patch clustermanagementaddon managed-serviceaccount --type=merge \
+	--patch '{"spec":{"installStrategy":{"type":"Manual","placements":[]}}}'
+
+hub_info=$(clusteradm get token -o json)
+hub_token=$(jq -r '."hub-token"' <<<"${hub_info}")
+hub_apiserver=$(jq -r '."hub-apiserver"' <<<"${hub_info}")
+
+join_cluster() {
+	local kubeconfig=$1
+	local cluster_name=$2
+	shift 2
+
+	KUBECONFIG="${kubeconfig}" clusteradm join \
+		--hub-token "${hub_token}" \
+		--hub-apiserver "${hub_apiserver}" \
+		--cluster-name "${cluster_name}" \
+		--wait \
+		--force-internal-endpoint-lookup \
+		"$@"
+}
+
+join_cluster "${kubeconfig_dir}/${hosting_cluster}.kubeconfig" "${hosting_cluster}"
+clusteradm accept --clusters "${hosting_cluster}" --wait 30
+kubectl wait --for=condition=ManagedClusterConditionAvailable \
+	"managedcluster/${hosting_cluster}" --timeout=2m
+
+# Prevent any incorrectly placed addon workload from becoming Ready on the
+# managed cluster. A final assertion also rejects even Pending addon pods.
+kubectl --kubeconfig="${kubeconfig_dir}/${spoke_cluster}.kubeconfig" \
+	wait --for=condition=Ready nodes --all --timeout=2m
+kubectl --kubeconfig="${kubeconfig_dir}/${spoke_cluster}.kubeconfig" taint nodes --all \
+	hosted-e2e.open-cluster-management.io/no-addon-workloads=true:NoSchedule --overwrite
+
+join_cluster \
+	"${kubeconfig_dir}/${hosting_cluster}.kubeconfig" \
+	"${spoke_cluster}" \
+	--mode hosted \
+	--managed-cluster-kubeconfig "${kubeconfig_dir}/${spoke_cluster}.kubeconfig"
+clusteradm accept --clusters "${spoke_cluster}" --wait 30
+kubectl wait --for=condition=ManagedClusterConditionAvailable \
+	"managedcluster/${spoke_cluster}" --timeout=2m
+
+# The e2e BeforeSuite creates the external kubeconfig source namespace and
+# Secret before it creates or converts the ManagedClusterAddOn to Hosted mode,
+# avoiding an expected first ManifestWork failure.

--- a/pkg/addon/agent/health/lease.go
+++ b/pkg/addon/agent/health/lease.go
@@ -12,16 +12,18 @@ import (
 func NewAddonHealthUpdater(
 	hubClientCfg *rest.Config,
 	clusterName string,
-	spokeClientCfg *rest.Config,
-	spokeNamespace string,
+	leaseClientCfg *rest.Config,
+	leaseNamespace string,
+	healthCheckFuncs ...func() bool,
 ) (lease.LeaseUpdater, error) {
-	spokeClient, err := kubernetes.NewForConfig(spokeClientCfg)
+	leaseClient, err := kubernetes.NewForConfig(leaseClientCfg)
 	if err != nil {
 		return nil, err
 	}
 	return lease.NewLeaseUpdater(
-		spokeClient,
+		leaseClient,
 		common.AddonName,
-		spokeNamespace,
+		leaseNamespace,
+		healthCheckFuncs...,
 	).WithHubLeaseConfig(hubClientCfg, clusterName), nil
 }

--- a/pkg/addon/manager/addon.go
+++ b/pkg/addon/manager/addon.go
@@ -7,6 +7,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"strconv"
+	"strings"
+	"time"
 
 	certificatesv1 "k8s.io/api/certificates/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -15,6 +17,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/client-go/kubernetes"
 
 	"open-cluster-management.io/addon-framework/pkg/addonfactory"
@@ -22,6 +25,7 @@ import (
 	addonutils "open-cluster-management.io/addon-framework/pkg/utils"
 	addonv1beta1 "open-cluster-management.io/api/addon/v1beta1"
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
+	"open-cluster-management.io/managed-serviceaccount/pkg/addon/provisioner"
 	"open-cluster-management.io/managed-serviceaccount/pkg/common"
 )
 
@@ -33,6 +37,15 @@ var FS embed.FS
 const (
 	prometheusEnabledVariableName              = "prometheusEnabled"
 	prometheusServiceMonitorLabelsVariableName = "prometheusServiceMonitorLabels"
+
+	externalManagedKubeConfigNamespaceVariableName       = "externalManagedKubeConfigNamespace"
+	externalManagedKubeConfigSecretVariableName          = "externalManagedKubeConfigSecret"
+	managedServiceAccountNameVariableName                = "managedServiceAccountName"
+	hubKubeConfigSecretVariableName                      = "hubKubeConfigSecret"
+	managedKubeConfigSecretVariableName                  = "managedKubeConfigSecret"
+	managedKubeConfigTokenExpirationSecondsVariableName  = "managedKubeConfigTokenExpirationSeconds"
+	managedKubeConfigRefreshBeforeVariableName           = "managedKubeConfigRefreshBefore"
+	managedKubeConfigProvisionerSyncIntervalVariableName = "managedKubeConfigProvisionerSyncInterval"
 )
 
 type prometheusValues struct {
@@ -61,6 +74,9 @@ func GetDefaultValues(image string, imagePullSecret *corev1.Secret, enableNetwor
 	return func(_ *clusterv1.ManagedCluster, _ *addonv1beta1.ManagedClusterAddOn) (addonfactory.Values, error) {
 		values := addonfactory.Values{
 			"Image": image,
+			"managedKubeConfigTokenExpirationSeconds":  provisioner.DefaultTokenExpirationSeconds,
+			"managedKubeConfigRefreshBefore":           provisioner.DefaultRefreshBefore.String(),
+			"managedKubeConfigProvisionerSyncInterval": provisioner.DefaultSyncInterval.String(),
 			"networkPolicies": map[string]interface{}{
 				"enabled": enableNetworkPolicies,
 			},
@@ -107,6 +123,60 @@ func ToAddOnPrometheusValues(config addonv1beta1.AddOnDeploymentConfig) (addonfa
 	}
 
 	return addonfactory.Values{"Prometheus": addonfactory.StructToValues(prometheus)}, nil
+}
+
+// ValidateAddOnAgentVariables validates every customized variable the agent
+// chart expands into command-line arguments, serviceAccountName, volume
+// secretName, or RBAC resourceNames, so an invalid value (including an empty
+// one, which would override the chart default) fails at render time as an
+// addon condition instead of a crash-looping pod.
+func ValidateAddOnAgentVariables(config addonv1beta1.AddOnDeploymentConfig) (addonfactory.Values, error) {
+	tokenExpirationSeconds := provisioner.DefaultTokenExpirationSeconds
+	refreshBefore := provisioner.DefaultRefreshBefore
+	syncInterval := provisioner.DefaultSyncInterval
+
+	for _, variable := range config.Spec.CustomizedVariables {
+		var errs []string
+		switch variable.Name {
+		case externalManagedKubeConfigNamespaceVariableName:
+			// An empty namespace is valid: the chart's default helper falls
+			// back to the cluster name.
+			if len(variable.Value) > 0 {
+				errs = validation.IsDNS1123Label(variable.Value)
+			}
+		case externalManagedKubeConfigSecretVariableName, managedServiceAccountNameVariableName,
+			managedKubeConfigSecretVariableName:
+			errs = validation.IsDNS1123Subdomain(variable.Value)
+		case hubKubeConfigSecretVariableName:
+			return nil, fmt.Errorf(
+				"customizing %s is unsupported because addon registration always manages the default secret name",
+				hubKubeConfigSecretVariableName,
+			)
+		case managedKubeConfigRefreshBeforeVariableName, managedKubeConfigProvisionerSyncIntervalVariableName:
+			value, err := time.ParseDuration(variable.Value)
+			if err != nil {
+				return nil, fmt.Errorf("invalid %s: %w", variable.Name, err)
+			}
+			if variable.Name == managedKubeConfigRefreshBeforeVariableName {
+				refreshBefore = value
+			} else {
+				syncInterval = value
+			}
+		case managedKubeConfigTokenExpirationSecondsVariableName:
+			value, err := strconv.ParseInt(variable.Value, 10, 64)
+			if err != nil {
+				return nil, fmt.Errorf("invalid %s: %w", variable.Name, err)
+			}
+			tokenExpirationSeconds = value
+		}
+		if len(errs) > 0 {
+			return nil, fmt.Errorf("invalid %s %q: %s", variable.Name, variable.Value, strings.Join(errs, ", "))
+		}
+	}
+	if err := provisioner.ValidateRotationSettings(tokenExpirationSeconds, refreshBefore, syncInterval); err != nil {
+		return nil, fmt.Errorf("invalid managed kubeconfig rotation settings: %w", err)
+	}
+	return nil, nil
 }
 
 func NewRegistrationOption(nativeClient kubernetes.Interface) *agent.RegistrationOption {

--- a/pkg/addon/manager/addon_test.go
+++ b/pkg/addon/manager/addon_test.go
@@ -2,7 +2,9 @@ package manager
 
 import (
 	"context"
+	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	appsv1 "k8s.io/api/apps/v1"
@@ -10,17 +12,21 @@ import (
 	networkingv1 "k8s.io/api/networking/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	fakekube "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/utils/ptr"
+	"sigs.k8s.io/yaml"
+
 	"open-cluster-management.io/addon-framework/pkg/addonfactory"
 	"open-cluster-management.io/addon-framework/pkg/agent"
 	"open-cluster-management.io/addon-framework/pkg/utils"
 	addonv1beta1 "open-cluster-management.io/api/addon/v1beta1"
 	fakeaddon "open-cluster-management.io/api/client/addon/clientset/versioned/fake"
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
+	"open-cluster-management.io/managed-serviceaccount/pkg/addon/provisioner"
 	"open-cluster-management.io/managed-serviceaccount/pkg/common"
 )
 
@@ -246,7 +252,7 @@ func TestManifestAddonAgent(t *testing.T) {
 				assert.Contains(t, container.Args, "--cluster-name="+clusterName)
 				assert.Equal(t, c.expectedNodeSelector, agentDeployment.Spec.Template.Spec.NodeSelector)
 				assert.Equal(t, c.expectedTolerations, agentDeployment.Spec.Template.Spec.Tolerations)
-				assertHubKubeconfigSecret(t, agentDeployment, hubKubeconfigSecretName)
+				assertDeploymentSecretVolume(t, agentDeployment, "hub-kubeconfig", hubKubeconfigSecretName)
 			}
 		})
 	}
@@ -298,6 +304,25 @@ func TestGetDefaultValuesRequiresDockerConfigJsonKey(t *testing.T) {
 			assert.ErrorContains(t, err, `missing ".dockerconfigjson"`)
 		})
 	}
+}
+
+func TestAgentChartRotationDefaultsMatchProvisioner(t *testing.T) {
+	data, err := FS.ReadFile("manifests/charts/managed-serviceaccount-agent/values.yaml")
+	assert.NoError(t, err)
+
+	values := struct {
+		TokenExpirationSeconds int64  `json:"managedKubeConfigTokenExpirationSeconds"`
+		RefreshBefore          string `json:"managedKubeConfigRefreshBefore"`
+		SyncInterval           string `json:"managedKubeConfigProvisionerSyncInterval"`
+	}{}
+	assert.NoError(t, yaml.Unmarshal(data, &values))
+	assert.Equal(t, provisioner.DefaultTokenExpirationSeconds, values.TokenExpirationSeconds)
+	refreshBefore, err := time.ParseDuration(values.RefreshBefore)
+	assert.NoError(t, err)
+	assert.Equal(t, provisioner.DefaultRefreshBefore, refreshBefore)
+	syncInterval, err := time.ParseDuration(values.SyncInterval)
+	assert.NoError(t, err)
+	assert.Equal(t, provisioner.DefaultSyncInterval, syncInterval)
 }
 
 func TestManifestAddonAgentUsesDeploymentConfigInstallNamespace(t *testing.T) {
@@ -384,36 +409,534 @@ func assertAgentSecurityContext(t *testing.T, deployment *appsv1.Deployment) {
 	t.Helper()
 
 	podSpec := deployment.Spec.Template.Spec
-	assert.Equal(t, &corev1.PodSecurityContext{
-		RunAsNonRoot:   ptr.To(true),
-		SeccompProfile: &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
-	}, podSpec.SecurityContext)
+	assertPodSecurityContext(t, podSpec)
 
 	if !assert.Len(t, podSpec.Containers, 1, "expected one addon agent container") {
 		return
 	}
+	assertContainerSecurityContext(t, podSpec.Containers[0])
+}
+
+func assertPodSecurityContext(t *testing.T, podSpec corev1.PodSpec) {
+	t.Helper()
+
+	assert.Equal(t, &corev1.PodSecurityContext{
+		RunAsNonRoot:   ptr.To(true),
+		SeccompProfile: &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
+	}, podSpec.SecurityContext)
+}
+
+func assertContainerSecurityContext(t *testing.T, container corev1.Container) {
+	t.Helper()
+
 	assert.Equal(t, &corev1.SecurityContext{
 		AllowPrivilegeEscalation: ptr.To(false),
 		ReadOnlyRootFilesystem:   ptr.To(true),
 		Capabilities:             &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
-	}, podSpec.Containers[0].SecurityContext)
+	}, container.SecurityContext)
 }
 
-func assertHubKubeconfigSecret(t *testing.T, deployment *appsv1.Deployment, expectedSecretName string) {
-	t.Helper()
+func TestManifestAddonAgentDeploymentOnManagedCluster(t *testing.T) {
+	clusterName := "cluster1"
+	addonName := "addon1"
+	imageName := "imageName1"
 
-	var hubKubeconfigVolume *corev1.Volume
-	for i := range deployment.Spec.Template.Spec.Volumes {
-		if deployment.Spec.Template.Spec.Volumes[i].Name == "hub-kubeconfig" {
-			hubKubeconfigVolume = &deployment.Spec.Template.Spec.Volumes[i]
-			break
-		}
+	// An addon without a hosting-cluster annotation still renders the agent on the
+	// managed cluster.
+	manifests := renderTestManifests(
+		t,
+		newTestCluster(clusterName),
+		newTestAddOn(addonName, clusterName),
+		GetDefaultValues(imageName, nil, false),
+	)
+	deployment := findDeployment(t, manifests)
+	container := deployment.Spec.Template.Spec.Containers[0]
+
+	assert.NotContains(t, deployment.Annotations, addonv1beta1.HostedManifestLocationAnnotationKey)
+	assert.Contains(t, container.Args, "--leader-elect=false")
+	assert.Contains(t, container.Args, "--cluster-name="+clusterName)
+	assert.Contains(t, container.Args, "--install-mode=Default")
+	assert.Contains(t, container.Args, "--kubeconfig=/etc/hub/kubeconfig")
+	assert.Contains(t, container.Args, "--lease-health-check=true")
+	// The args and volumes hosted gates are independent template blocks, so
+	// the missing-volume assert below does not cover this flag.
+	assert.NotContains(t, container.Args, "--spoke-kubeconfig=/etc/managed/kubeconfig")
+	assertDeploymentSecretVolume(t, deployment, "hub-kubeconfig", "managed-serviceaccount-hub-kubeconfig")
+	assertDeploymentMissingVolume(t, deployment, "managed-kubeconfig")
+
+	role := findRole(t, manifests, "open-cluster-management:managed-serviceaccount:addon-agent", "")
+	assertRule(t, role.Rules, []string{"coordination.k8s.io"}, []string{"leases"}, []string{"get", "create", "update", "patch"}, nil)
+	assertHostedManifestMissing[*rbacv1.Role](t, manifests, "managed-serviceaccount-health-lease", addonv1beta1.HostedManifestLocationHostingValue)
+}
+
+func TestManifestAddonAgentHostedModeDeployment(t *testing.T) {
+	clusterName := "cluster1"
+	addonName := "addon1"
+	imageName := "imageName1"
+
+	manifests := renderTestManifests(
+		t,
+		newTestCluster(clusterName),
+		newTestHostedAddOn(addonName, clusterName, "hosting1"),
+		GetDefaultValues(imageName, nil, false),
+	)
+	deployment := findDeployment(t, manifests)
+	container := deployment.Spec.Template.Spec.Containers[0]
+
+	assert.Equal(t,
+		addonv1beta1.HostedManifestLocationHostingValue,
+		deployment.Annotations[addonv1beta1.HostedManifestLocationAnnotationKey])
+	assert.Contains(t, container.Args, "--install-mode=Hosted")
+	assert.Contains(t, container.Args, "--kubeconfig=/etc/hub/kubeconfig")
+	assert.Contains(t, container.Args, "--spoke-kubeconfig=/etc/managed/kubeconfig")
+	assert.Contains(t, container.Args, "--lease-health-check=true")
+	assertDeploymentSecretVolume(t, deployment, "hub-kubeconfig", "managed-serviceaccount-hub-kubeconfig")
+	assertDeploymentSecretVolume(t, deployment, "managed-kubeconfig", addonName+"-managed-kubeconfig")
+	assertDeploymentVolumeMount(t, deployment, "hub-kubeconfig", "/etc/hub/")
+	assertDeploymentVolumeMount(t, deployment, "managed-kubeconfig", "/etc/managed/")
+}
+
+func TestManifestAddonAgentHostedModeManagedKubeConfigSecretOverride(t *testing.T) {
+	clusterName := "cluster1"
+	addonName := "addon1"
+	imageName := "imageName1"
+	managedKubeConfigSecret := "custom-managed-kubeconfig"
+
+	manifests := renderTestManifests(
+		t,
+		newTestCluster(clusterName),
+		newTestHostedAddOn(addonName, clusterName, "hosting1"),
+		GetDefaultValues(imageName, nil, false),
+		func(_ *clusterv1.ManagedCluster, _ *addonv1beta1.ManagedClusterAddOn) (addonfactory.Values, error) {
+			return addonfactory.Values{
+				"managedKubeConfigSecret": managedKubeConfigSecret,
+			}, nil
+		},
+	)
+	deployment := findDeployment(t, manifests)
+
+	assertDeploymentSecretVolume(t, deployment, "managed-kubeconfig", managedKubeConfigSecret)
+}
+
+func TestManifestAddonAgentHostedModeSecretNameCannotInjectManifestStructure(t *testing.T) {
+	clusterName := "cluster1"
+	addonName := "addon1"
+	imageName := "imageName1"
+	// Bypasses ValidateAddOnAgentVariables on purpose: the chart's own quoting
+	// must keep a newline-bearing value a single scalar even if validation
+	// regresses. The indentation lands hostNetwork in the pod spec if quoting
+	// is ever removed, which the HostNetwork assert below would catch.
+	injectedValue := "evil\n      hostNetwork: true"
+
+	manifests := renderTestManifests(
+		t,
+		newTestCluster(clusterName),
+		newTestHostedAddOn(addonName, clusterName, "hosting1"),
+		GetDefaultValues(imageName, nil, false),
+		func(_ *clusterv1.ManagedCluster, _ *addonv1beta1.ManagedClusterAddOn) (addonfactory.Values, error) {
+			return addonfactory.Values{
+				"managedKubeConfigSecret": injectedValue,
+			}, nil
+		},
+	)
+	deployment := findDeployment(t, manifests)
+
+	assert.False(t, deployment.Spec.Template.Spec.HostNetwork)
+	assertDeploymentSecretVolume(t, deployment, "managed-kubeconfig", injectedValue)
+}
+
+func TestManifestAddonAgentHostedModeManifestLocations(t *testing.T) {
+	clusterName := "cluster1"
+	addonName := "addon1"
+	imageName := "imageName1"
+
+	manifests := renderTestManifests(
+		t,
+		newTestCluster(clusterName),
+		newTestHostedAddOn(addonName, clusterName, "hosting1"),
+		GetDefaultValues(imageName, newTestImagePullSecret(), false),
+	)
+
+	// The finders match on name and hosted location, so a successful lookup is the assertion.
+	findServiceAccount(t, manifests, "managed-serviceaccount", "")
+	findServiceAccount(t, manifests, "managed-serviceaccount", addonv1beta1.HostedManifestLocationHostingValue)
+	findRole(t, manifests, "open-cluster-management:managed-serviceaccount:addon-agent", "")
+	findRoleBinding(t, manifests, "open-cluster-management:managed-serviceaccount:addon-agent", "")
+	assertHostedManifestMissing[*rbacv1.Role](
+		t, manifests, "open-cluster-management:managed-serviceaccount:addon-agent",
+		addonv1beta1.HostedManifestLocationHostingValue)
+	assertHostedManifestMissing[*rbacv1.RoleBinding](
+		t, manifests, "open-cluster-management:managed-serviceaccount:addon-agent",
+		addonv1beta1.HostedManifestLocationHostingValue)
+
+	assert.Equal(t, addonv1beta1.HostedManifestLocationHostingValue, hostedLocation(findDeployment(t, manifests)))
+	assert.Equal(t, addonv1beta1.HostedManifestLocationHostingValue,
+		hostedLocation(findDeploymentByName(t, manifests, "managed-serviceaccount-kubeconfig-provisioner")))
+	findSecret(t, manifests, "open-cluster-management-image-pull-credentials", addonv1beta1.HostedManifestLocationHostingValue)
+	findServiceAccount(t, manifests, "managed-serviceaccount-kubeconfig-provisioner", addonv1beta1.HostedManifestLocationHostingValue)
+	findRole(t, manifests, "managed-serviceaccount-kubeconfig-provisioner", addonv1beta1.HostedManifestLocationHostingValue)
+	findRoleBinding(t, manifests, "managed-serviceaccount-kubeconfig-provisioner", addonv1beta1.HostedManifestLocationHostingValue)
+	findRoleBinding(t, manifests, testProvisionerSourceRBACName(addonName), addonv1beta1.HostedManifestLocationHostingValue)
+	findRole(t, manifests, "managed-serviceaccount-health-lease", addonv1beta1.HostedManifestLocationHostingValue)
+	findRoleBinding(t, manifests, "managed-serviceaccount-health-lease", addonv1beta1.HostedManifestLocationHostingValue)
+	assertHostedManifestMissing[*networkingv1.NetworkPolicy](
+		t, manifests, "managed-serviceaccount-kubeconfig-provisioner-network-policy",
+		addonv1beta1.HostedManifestLocationHostingValue)
+
+	// An unannotated manifest goes to the managed cluster, like the Role/RoleBinding/ServiceAccount above.
+	assert.Empty(t,
+		hostedLocation(findClusterRole(t, manifests, "open-cluster-management:managed-serviceaccount:addon-agent")))
+	assert.Empty(t,
+		hostedLocation(findClusterRoleBinding(t, manifests, "open-cluster-management:managed-serviceaccount:addon-agent")))
+}
+
+func TestManifestAddonAgentHostedModeLeaseRBAC(t *testing.T) {
+	clusterName := "cluster1"
+	addonName := "addon1"
+	imageName := "imageName1"
+
+	manifests := renderTestManifests(
+		t,
+		newTestCluster(clusterName),
+		newTestHostedAddOn(addonName, clusterName, "hosting1"),
+		GetDefaultValues(imageName, nil, false),
+	)
+
+	deployment := findDeployment(t, manifests)
+	assert.Contains(t, deployment.Spec.Template.Spec.Containers[0].Args, "--lease-health-check=true")
+	assert.Contains(t, deployment.Spec.Template.Spec.Containers[0].Args, "--install-mode=Hosted")
+
+	role := findRole(t, manifests, "open-cluster-management:managed-serviceaccount:addon-agent", "")
+	assert.Equal(t, addonName, role.Namespace)
+	for _, rule := range role.Rules {
+		assert.NotContains(t, rule.APIGroups, "coordination.k8s.io",
+			"an agent running on a hosting cluster should have lease permissions only there")
 	}
 
-	if assert.NotNil(t, hubKubeconfigVolume, "expected hub kubeconfig volume") &&
-		assert.NotNil(t, hubKubeconfigVolume.Secret, "expected hub kubeconfig volume to use a secret") {
-		assert.Equal(t, expectedSecretName, hubKubeconfigVolume.Secret.SecretName)
+	binding := findRoleBinding(t, manifests, "open-cluster-management:managed-serviceaccount:addon-agent", "")
+	assert.Equal(t, addonName, binding.Namespace)
+	assertRoleBindingBinds(t, binding, "open-cluster-management:managed-serviceaccount:addon-agent", "managed-serviceaccount", addonName)
+
+	hostingRole := findRole(t, manifests, "managed-serviceaccount-health-lease", addonv1beta1.HostedManifestLocationHostingValue)
+	assert.Equal(t, addonName, hostingRole.Namespace)
+	assertRule(t, hostingRole.Rules, []string{"coordination.k8s.io"}, []string{"leases"}, []string{"create"}, nil)
+	assertRule(t, hostingRole.Rules, []string{"coordination.k8s.io"}, []string{"leases"}, []string{"get", "update", "patch"}, []string{"managed-serviceaccount"})
+
+	hostingBinding := findRoleBinding(t, manifests, "managed-serviceaccount-health-lease", addonv1beta1.HostedManifestLocationHostingValue)
+	assert.Equal(t, addonName, hostingBinding.Namespace)
+	assertRoleBindingBinds(t, hostingBinding, "managed-serviceaccount-health-lease", "managed-serviceaccount", addonName)
+}
+
+func TestManifestAddonAgentHostedModeExternalManagedKubeConfigOverrides(t *testing.T) {
+	clusterName := "cluster1"
+	addonName := "addon1"
+	imageName := "imageName1"
+
+	manifests := renderTestManifests(
+		t,
+		newTestCluster(clusterName),
+		newTestHostedAddOn(addonName, clusterName, "hosting1"),
+		GetDefaultValues(imageName, nil, false),
+		func(_ *clusterv1.ManagedCluster, _ *addonv1beta1.ManagedClusterAddOn) (addonfactory.Values, error) {
+			return addonfactory.Values{
+				"externalManagedKubeConfigNamespace": "custom-source-ns",
+				"externalManagedKubeConfigSecret":    "custom-source-secret",
+				"managedKubeConfigSecret":            "custom-target-secret",
+			}, nil
+		},
+	)
+
+	prov := findDeploymentByName(t, manifests, "managed-serviceaccount-kubeconfig-provisioner")
+	args := prov.Spec.Template.Spec.Containers[0].Args
+	assert.Contains(t, args, "--source-namespace=custom-source-ns")
+	assert.Contains(t, args, "--source-secret=custom-source-secret")
+	assert.Contains(t, args, "--target-secret=custom-target-secret")
+
+	targetRole := findRole(t, manifests, "managed-serviceaccount-kubeconfig-provisioner", addonv1beta1.HostedManifestLocationHostingValue)
+	assert.Equal(t, addonName, targetRole.Namespace)
+	assertRule(t, targetRole.Rules, []string{""}, []string{"secrets"}, []string{"get", "update"}, []string{"custom-target-secret"})
+	assertRule(t, targetRole.Rules, []string{""}, []string{"secrets"}, []string{"create"}, nil)
+	assertRule(t, targetRole.Rules, []string{""}, []string{"serviceaccounts"}, []string{"get"}, []string{"managed-serviceaccount-kubeconfig-provisioner"})
+	assertRule(t, targetRole.Rules, []string{"events.k8s.io"}, []string{"events"}, []string{"create", "patch", "update"}, nil)
+
+	sourceRBACName := testProvisionerSourceRBACName(addonName)
+	sourceRole := findRole(t, manifests, sourceRBACName, addonv1beta1.HostedManifestLocationHostingValue)
+	assert.Equal(t, "custom-source-ns", sourceRole.Namespace)
+	assertRule(t, sourceRole.Rules, []string{""}, []string{"secrets"}, []string{"get"}, []string{"custom-source-secret"})
+
+	sourceBinding := findRoleBinding(t, manifests, sourceRBACName, addonv1beta1.HostedManifestLocationHostingValue)
+	assert.Equal(t, "custom-source-ns", sourceBinding.Namespace)
+	assertRoleBindingBinds(t, sourceBinding, sourceRBACName, "managed-serviceaccount-kubeconfig-provisioner", addonName)
+}
+
+func TestManifestAddonAgentHostedModeSourceRBACNamesAreUniqueInSharedNamespace(t *testing.T) {
+	sourceNamespace := "shared-source"
+	firstAddonName := "addon1"
+	secondAddonName := "addon2"
+
+	render := func(clusterName, addonName, sourceSecret string) []runtime.Object {
+		return renderTestManifests(
+			t,
+			newTestCluster(clusterName),
+			newTestHostedAddOn(addonName, clusterName, "hosting1"),
+			GetDefaultValues("imageName1", nil, false),
+			func(_ *clusterv1.ManagedCluster, _ *addonv1beta1.ManagedClusterAddOn) (addonfactory.Values, error) {
+				return addonfactory.Values{
+					"externalManagedKubeConfigNamespace": sourceNamespace,
+					"externalManagedKubeConfigSecret":    sourceSecret,
+				}, nil
+			},
+		)
 	}
+
+	firstManifests := render("cluster1", firstAddonName, "cluster1-kubeconfig")
+	secondManifests := render("cluster2", secondAddonName, "cluster2-kubeconfig")
+	firstName := testProvisionerSourceRBACName(firstAddonName)
+	secondName := testProvisionerSourceRBACName(secondAddonName)
+
+	assert.NotEqual(t, firstName, secondName)
+	for _, test := range []struct {
+		manifests        []runtime.Object
+		name             string
+		sourceSecret     string
+		subjectNamespace string
+	}{
+		{
+			manifests:        firstManifests,
+			name:             firstName,
+			sourceSecret:     "cluster1-kubeconfig",
+			subjectNamespace: firstAddonName,
+		},
+		{
+			manifests:        secondManifests,
+			name:             secondName,
+			sourceSecret:     "cluster2-kubeconfig",
+			subjectNamespace: secondAddonName,
+		},
+	} {
+		role := findRole(t, test.manifests, test.name, addonv1beta1.HostedManifestLocationHostingValue)
+		assert.Equal(t, sourceNamespace, role.Namespace)
+		assertRule(t, role.Rules, []string{""}, []string{"secrets"}, []string{"get"}, []string{test.sourceSecret})
+
+		binding := findRoleBinding(t, test.manifests, test.name, addonv1beta1.HostedManifestLocationHostingValue)
+		assert.Equal(t, sourceNamespace, binding.Namespace)
+		assertRoleBindingBinds(t, binding, test.name, "managed-serviceaccount-kubeconfig-provisioner", test.subjectNamespace)
+	}
+}
+
+func TestManifestAddonAgentHostedModeProvisioner(t *testing.T) {
+	clusterName := "cluster1"
+	addonName := "addon1"
+	imageName := "imageName1"
+	resources := corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("10m"),
+			corev1.ResourceMemory: resource.MustParse("32Mi"),
+		},
+		Limits: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("100m"),
+			corev1.ResourceMemory: resource.MustParse("128Mi"),
+		},
+	}
+	nodeSelector := map[string]string{"node-role.kubernetes.io/hosting": "true"}
+	tolerations := []corev1.Toleration{{Key: "dedicated", Operator: corev1.TolerationOpEqual, Value: "hosting", Effect: corev1.TaintEffectNoSchedule}}
+
+	cases := []struct {
+		name     string
+		values   addonfactory.GetValuesFunc
+		validate func(t *testing.T, manifests []runtime.Object, prov *appsv1.Deployment)
+	}{
+		{
+			name: "source configuration and RBAC",
+			validate: func(t *testing.T, manifests []runtime.Object, prov *appsv1.Deployment) {
+				args := prov.Spec.Template.Spec.Containers[0].Args
+				assert.Contains(t, args, "--source-namespace="+clusterName)
+				assert.Contains(t, args, "--source-secret=external-managed-kubeconfig")
+				assert.Contains(t, args, "--target-secret="+addonName+"-managed-kubeconfig")
+				assert.Contains(t, args, "--hosting-service-account-name=managed-serviceaccount-kubeconfig-provisioner")
+
+				sourceRBACName := testProvisionerSourceRBACName(addonName)
+				sourceRole := findRole(t, manifests, sourceRBACName, addonv1beta1.HostedManifestLocationHostingValue)
+				assert.Equal(t, clusterName, sourceRole.Namespace)
+				assertRule(t, sourceRole.Rules, []string{""}, []string{"secrets"}, []string{"get"}, []string{"external-managed-kubeconfig"})
+
+				sourceBinding := findRoleBinding(t, manifests, sourceRBACName, addonv1beta1.HostedManifestLocationHostingValue)
+				assert.Equal(t, clusterName, sourceBinding.Namespace)
+				assertRoleBindingBinds(t, sourceBinding, sourceRBACName, "managed-serviceaccount-kubeconfig-provisioner", addonName)
+			},
+		},
+		{
+			name: "timing defaults",
+			validate: func(t *testing.T, _ []runtime.Object, prov *appsv1.Deployment) {
+				args := prov.Spec.Template.Spec.Containers[0].Args
+				assert.Contains(t, args, fmt.Sprintf("--token-expiration-seconds=%d", provisioner.DefaultTokenExpirationSeconds))
+				assert.Contains(t, args, "--refresh-before="+provisioner.DefaultRefreshBefore.String())
+				assert.Contains(t, args, "--sync-interval="+provisioner.DefaultSyncInterval.String())
+			},
+		},
+		{
+			name: "timing overrides",
+			values: func(_ *clusterv1.ManagedCluster, _ *addonv1beta1.ManagedClusterAddOn) (addonfactory.Values, error) {
+				return addonfactory.Values{
+					"managedKubeConfigTokenExpirationSeconds":  int64(7200),
+					"managedKubeConfigRefreshBefore":           "15m",
+					"managedKubeConfigProvisionerSyncInterval": "30s",
+				}, nil
+			},
+			validate: func(t *testing.T, _ []runtime.Object, prov *appsv1.Deployment) {
+				args := prov.Spec.Template.Spec.Containers[0].Args
+				assert.Contains(t, args, "--token-expiration-seconds=7200")
+				assert.Contains(t, args, "--refresh-before=15m")
+				assert.Contains(t, args, "--sync-interval=30s")
+			},
+		},
+		{
+			name: "resource requirements",
+			values: func(_ *clusterv1.ManagedCluster, _ *addonv1beta1.ManagedClusterAddOn) (addonfactory.Values, error) {
+				return addonfactory.ToAddOnDeploymentConfigValues(addonv1beta1.AddOnDeploymentConfig{
+					Spec: addonv1beta1.AddOnDeploymentConfigSpec{
+						ResourceRequirements: []addonv1beta1.ContainerResourceRequirements{
+							{
+								ContainerID: "deployments:managed-serviceaccount-kubeconfig-provisioner:kubeconfig-provisioner",
+								Resources:   resources,
+							},
+						},
+					},
+				})
+			},
+			validate: func(t *testing.T, _ []runtime.Object, prov *appsv1.Deployment) {
+				if assert.Len(t, prov.Spec.Template.Spec.Containers, 1, "expected one provisioner container") {
+					assert.Equal(t, resources, prov.Spec.Template.Spec.Containers[0].Resources)
+				}
+			},
+		},
+		{
+			name: "security context",
+			validate: func(t *testing.T, _ []runtime.Object, prov *appsv1.Deployment) {
+				assertPodSecurityContext(t, prov.Spec.Template.Spec)
+				if assert.Len(t, prov.Spec.Template.Spec.Containers, 1, "expected one provisioner container") {
+					assertContainerSecurityContext(t, prov.Spec.Template.Spec.Containers[0])
+				}
+			},
+		},
+		{
+			name:   "node placement",
+			values: getNodePlacementValues(nodeSelector, tolerations),
+			validate: func(t *testing.T, _ []runtime.Object, prov *appsv1.Deployment) {
+				assert.Equal(t, nodeSelector, prov.Spec.Template.Spec.NodeSelector)
+				assert.Equal(t, tolerations, prov.Spec.Template.Spec.Tolerations)
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			getValuesFuncs := []addonfactory.GetValuesFunc{GetDefaultValues(imageName, nil, false)}
+			if c.values != nil {
+				getValuesFuncs = append(getValuesFuncs, c.values)
+			}
+			manifests := renderTestManifests(
+				t,
+				newTestCluster(clusterName),
+				newTestHostedAddOn(addonName, clusterName, "hosting1"),
+				getValuesFuncs...,
+			)
+			c.validate(t, manifests, findDeploymentByName(t, manifests, "managed-serviceaccount-kubeconfig-provisioner"))
+		})
+	}
+}
+
+func TestManifestAddonAgentServiceAccountNameOverrideOnManagedCluster(t *testing.T) {
+	clusterName := "cluster1"
+	addonName := "addon1"
+	imageName := "imageName1"
+	customName := "custom-msa"
+	installNamespace := addonfactory.AddonDefaultInstallNamespace
+
+	manifests := renderTestManifests(
+		t,
+		newTestCluster(clusterName),
+		newTestAddOn(addonName, clusterName),
+		GetDefaultValues(imageName, nil, false),
+		func(_ *clusterv1.ManagedCluster, _ *addonv1beta1.ManagedClusterAddOn) (addonfactory.Values, error) {
+			return addonfactory.Values{
+				"managedServiceAccountName": customName,
+			}, nil
+		},
+	)
+
+	sa := findServiceAccount(t, manifests, customName, "")
+	assert.Equal(t, installNamespace, sa.Namespace)
+
+	binding := findRoleBinding(t, manifests, "open-cluster-management:managed-serviceaccount:addon-agent", "")
+	assert.Len(t, binding.Subjects, 1)
+	assert.Equal(t, customName, binding.Subjects[0].Name)
+	assert.Equal(t, installNamespace, binding.Subjects[0].Namespace)
+
+	clusterBinding := findClusterRoleBinding(t, manifests, "open-cluster-management:managed-serviceaccount:addon-agent")
+	assert.Len(t, clusterBinding.Subjects, 1)
+	assert.Equal(t, customName, clusterBinding.Subjects[0].Name)
+	assert.Equal(t, installNamespace, clusterBinding.Subjects[0].Namespace)
+
+	deployment := findDeployment(t, manifests)
+	assert.Equal(t, customName, deployment.Spec.Template.Spec.ServiceAccountName)
+}
+
+func TestManifestAddonAgentHostedModeManagedServiceAccountNameOverride(t *testing.T) {
+	clusterName := "cluster1"
+	addonName := "addon1"
+	imageName := "imageName1"
+	customName := "custom-msa"
+
+	manifests := renderTestManifests(
+		t,
+		newTestCluster(clusterName),
+		newTestHostedAddOn(addonName, clusterName, "hosting1"),
+		GetDefaultValues(imageName, nil, false),
+		func(_ *clusterv1.ManagedCluster, _ *addonv1beta1.ManagedClusterAddOn) (addonfactory.Values, error) {
+			return addonfactory.Values{
+				"managedServiceAccountName": customName,
+			}, nil
+		},
+	)
+
+	sa := findServiceAccount(t, manifests, customName, "")
+	assert.Equal(t, addonName, sa.Namespace)
+
+	binding := findRoleBinding(t, manifests, "open-cluster-management:managed-serviceaccount:addon-agent", "")
+	assert.Len(t, binding.Subjects, 1)
+	assert.Equal(t, customName, binding.Subjects[0].Name)
+	assert.Equal(t, addonName, binding.Subjects[0].Namespace)
+
+	clusterBinding := findClusterRoleBinding(t, manifests, "open-cluster-management:managed-serviceaccount:addon-agent")
+	assert.Len(t, clusterBinding.Subjects, 1)
+	assert.Equal(t, customName, clusterBinding.Subjects[0].Name)
+	assert.Equal(t, addonName, clusterBinding.Subjects[0].Namespace)
+
+	prov := findDeploymentByName(t, manifests, "managed-serviceaccount-kubeconfig-provisioner")
+	assert.Contains(t, prov.Spec.Template.Spec.Containers[0].Args, "--managed-serviceaccount-name="+customName)
+
+	deployment := findDeployment(t, manifests)
+	assert.Equal(t, "managed-serviceaccount", deployment.Spec.Template.Spec.ServiceAccountName)
+	hostingSA := findServiceAccount(t, manifests, "managed-serviceaccount", addonv1beta1.HostedManifestLocationHostingValue)
+	assert.Equal(t, addonName, hostingSA.Namespace)
+}
+
+func TestManifestAddonAgentHostedModeNamespaces(t *testing.T) {
+	clusterName := "cluster1"
+	addonName := "addon1"
+	imageName := "imageName1"
+
+	manifests := renderTestManifests(
+		t,
+		newTestCluster(clusterName),
+		newTestHostedAddOn(addonName, clusterName, "hosting1"),
+		GetDefaultValues(imageName, nil, false),
+	)
+
+	assert.Len(t, findNamespaces(manifests), 2)
+	findHostedManifest[*corev1.Namespace](t, manifests, addonName, addonv1beta1.HostedManifestLocationHostingValue)
+	findHostedManifest[*corev1.Namespace](t, manifests, addonName, "")
 }
 
 func TestManifestAddonServiceMonitor(t *testing.T) {
@@ -517,6 +1040,7 @@ func TestManifestAddonNetworkPolicy(t *testing.T) {
 				return
 			}
 			assert.Equal(t, "managed-serviceaccount-addon-agent-network-policy", np.Name)
+			assert.Empty(t, hostedLocation(np), "NetworkPolicy must stay with the agent on the managed cluster")
 			assert.Contains(t, np.Spec.PolicyTypes, networkingv1.PolicyTypeIngress)
 			assert.Contains(t, np.Spec.PolicyTypes, networkingv1.PolicyTypeEgress)
 			assert.True(t, networkPolicyAllowsEgressTCPPort(np, 443))
@@ -527,6 +1051,42 @@ func TestManifestAddonNetworkPolicy(t *testing.T) {
 				"health :8000 must be opened for kubelet livenessProbe")
 		})
 	}
+}
+
+func TestManifestAddonAgentHostedModeNetworkPolicy(t *testing.T) {
+	clusterName := "cluster1"
+	addonName := "addon1"
+
+	manifests := renderTestManifests(
+		t,
+		newTestCluster(clusterName),
+		newTestHostedAddOn(addonName, clusterName, "hosting1"),
+		GetDefaultValues("imageName1", nil, true),
+	)
+
+	networkPolicy := findHostedManifest[*networkingv1.NetworkPolicy](
+		t,
+		manifests,
+		"managed-serviceaccount-addon-agent-network-policy",
+		addonv1beta1.HostedManifestLocationHostingValue,
+	)
+	assert.Equal(t, addonName, networkPolicy.Namespace)
+
+	provisionerNetworkPolicy := findHostedManifest[*networkingv1.NetworkPolicy](
+		t,
+		manifests,
+		"managed-serviceaccount-kubeconfig-provisioner-network-policy",
+		addonv1beta1.HostedManifestLocationHostingValue,
+	)
+	assert.Equal(t, addonName, provisionerNetworkPolicy.Namespace)
+	assert.Equal(t, map[string]string{
+		"addon-agent": "managed-serviceaccount-kubeconfig-provisioner",
+	}, provisionerNetworkPolicy.Spec.PodSelector.MatchLabels)
+	assert.Contains(t, provisionerNetworkPolicy.Spec.PolicyTypes, networkingv1.PolicyTypeIngress)
+	assert.Contains(t, provisionerNetworkPolicy.Spec.PolicyTypes, networkingv1.PolicyTypeEgress)
+	assert.Empty(t, provisionerNetworkPolicy.Spec.Ingress)
+	assert.True(t, networkPolicyAllowsEgressTCPPort(provisionerNetworkPolicy, 443))
+	assert.True(t, networkPolicyAllowsEgressTCPPort(provisionerNetworkPolicy, 6443))
 }
 
 func TestToAddOnPrometheusValuesRejectsInvalidServiceMonitorLabels(t *testing.T) {
@@ -558,6 +1118,99 @@ func TestToAddOnPrometheusValuesRejectsInvalidServiceMonitorLabels(t *testing.T)
 	}
 }
 
+func TestValidateAddOnAgentVariables(t *testing.T) {
+	cases := []struct {
+		name          string
+		variables     []addonv1beta1.CustomizedVariable
+		expectedError bool
+	}{
+		{
+			name: "default values are valid",
+		},
+		{
+			name: "valid values pass through",
+			variables: []addonv1beta1.CustomizedVariable{
+				{Name: managedKubeConfigTokenExpirationSecondsVariableName, Value: "600"},
+				{Name: managedKubeConfigRefreshBeforeVariableName, Value: "599s"},
+				{Name: managedKubeConfigProvisionerSyncIntervalVariableName, Value: "30s"},
+			},
+		},
+		{
+			name:      "unrelated variables are ignored",
+			variables: []addonv1beta1.CustomizedVariable{{Name: "somethingElse", Value: "anything\ngoes"}},
+		},
+		{
+			name:      "allows empty source namespace",
+			variables: []addonv1beta1.CustomizedVariable{{Name: externalManagedKubeConfigNamespaceVariableName, Value: ""}},
+		},
+		{
+			name:          "rejects newline in source namespace",
+			variables:     []addonv1beta1.CustomizedVariable{{Name: externalManagedKubeConfigNamespaceVariableName, Value: "ns\nextra"}},
+			expectedError: true,
+		},
+		{
+			name:          "rejects invalid managed serviceaccount name",
+			variables:     []addonv1beta1.CustomizedVariable{{Name: managedServiceAccountNameVariableName, Value: "Not_A_Name"}},
+			expectedError: true,
+		},
+		{
+			name:          "rejects any hub kubeconfig secret override",
+			variables:     []addonv1beta1.CustomizedVariable{{Name: hubKubeConfigSecretVariableName, Value: "valid-secret-name"}},
+			expectedError: true,
+		},
+		{
+			name:          "rejects invalid managed kubeconfig secret name",
+			variables:     []addonv1beta1.CustomizedVariable{{Name: managedKubeConfigSecretVariableName, Value: "Not_A_Secret"}},
+			expectedError: true,
+		},
+		{
+			name:          "rejects empty source secret name",
+			variables:     []addonv1beta1.CustomizedVariable{{Name: externalManagedKubeConfigSecretVariableName, Value: ""}},
+			expectedError: true,
+		},
+		{
+			name:          "rejects non-duration refresh before",
+			variables:     []addonv1beta1.CustomizedVariable{{Name: managedKubeConfigRefreshBeforeVariableName, Value: "10 minutes"}},
+			expectedError: true,
+		},
+		{
+			name:          "rejects non-duration sync interval",
+			variables:     []addonv1beta1.CustomizedVariable{{Name: managedKubeConfigProvisionerSyncIntervalVariableName, Value: "five minutes"}},
+			expectedError: true,
+		},
+		{
+			name:          "rejects non-integer token expiration seconds",
+			variables:     []addonv1beta1.CustomizedVariable{{Name: managedKubeConfigTokenExpirationSecondsVariableName, Value: "3600s"}},
+			expectedError: true,
+		},
+		{
+			name:          "rejects token expiration below the Kubernetes minimum",
+			variables:     []addonv1beta1.CustomizedVariable{{Name: managedKubeConfigTokenExpirationSecondsVariableName, Value: "599"}},
+			expectedError: true,
+		},
+		{
+			name:          "validates customized token lifetime against the default refresh before",
+			variables:     []addonv1beta1.CustomizedVariable{{Name: managedKubeConfigTokenExpirationSecondsVariableName, Value: "600"}},
+			expectedError: true,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			_, err := ValidateAddOnAgentVariables(addonv1beta1.AddOnDeploymentConfig{
+				Spec: addonv1beta1.AddOnDeploymentConfigSpec{
+					CustomizedVariables: c.variables,
+				},
+			})
+			if c.expectedError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
 func renderTestManifests(
 	t *testing.T,
 	cluster *clusterv1.ManagedCluster,
@@ -578,11 +1231,11 @@ func renderTestManifestsWithNamespaceFunc(
 
 	agentFactory := addonfactory.NewAgentAddonFactory(common.AddonName, FS, "manifests/charts/managed-serviceaccount-agent").
 		WithScheme(NewAgentScheme()).
-		WithGetValuesFuncs(getValuesFuncs...)
+		WithGetValuesFuncs(getValuesFuncs...).
+		WithAgentRegistrationOption(NewRegistrationOption(fakekube.NewSimpleClientset()))
 	if agentInstallNamespace != nil {
 		agentFactory = agentFactory.WithAgentInstallNamespace(agentInstallNamespace)
 	}
-
 	addOnAgent, err := agentFactory.BuildHelmAgentAddon()
 	assert.NoError(t, err)
 
@@ -666,6 +1319,174 @@ func networkPolicyAllowsIngressTCPPort(np *networkingv1.NetworkPolicy, port int3
 	return false
 }
 
+func findDeployment(t *testing.T, manifests []runtime.Object) *appsv1.Deployment {
+	t.Helper()
+	return findDeploymentByName(t, manifests, "managed-serviceaccount-addon-agent")
+}
+
+func findDeploymentByName(t *testing.T, manifests []runtime.Object, name string) *appsv1.Deployment {
+	t.Helper()
+	return findManifestByName[*appsv1.Deployment](t, manifests, name)
+}
+
+func findSecret(t *testing.T, manifests []runtime.Object, name, location string) *corev1.Secret {
+	t.Helper()
+	return findHostedManifest[*corev1.Secret](t, manifests, name, location)
+}
+
+func findServiceAccount(t *testing.T, manifests []runtime.Object, name, location string) *corev1.ServiceAccount {
+	t.Helper()
+	return findHostedManifest[*corev1.ServiceAccount](t, manifests, name, location)
+}
+
+func findRole(t *testing.T, manifests []runtime.Object, name, location string) *rbacv1.Role {
+	t.Helper()
+	return findHostedManifest[*rbacv1.Role](t, manifests, name, location)
+}
+
+func findRoleBinding(t *testing.T, manifests []runtime.Object, name, location string) *rbacv1.RoleBinding {
+	t.Helper()
+	return findHostedManifest[*rbacv1.RoleBinding](t, manifests, name, location)
+}
+
+func findClusterRole(t *testing.T, manifests []runtime.Object, name string) *rbacv1.ClusterRole {
+	t.Helper()
+	return findManifestByName[*rbacv1.ClusterRole](t, manifests, name)
+}
+
+func findClusterRoleBinding(t *testing.T, manifests []runtime.Object, name string) *rbacv1.ClusterRoleBinding {
+	t.Helper()
+	return findManifestByName[*rbacv1.ClusterRoleBinding](t, manifests, name)
+}
+
+type manifestObject interface {
+	runtime.Object
+	metav1.Object
+}
+
+func findManifestByName[T manifestObject](t *testing.T, manifests []runtime.Object, name string) T {
+	t.Helper()
+
+	for _, manifest := range manifests {
+		obj, ok := manifest.(T)
+		if ok && obj.GetName() == name {
+			return obj
+		}
+	}
+
+	var zero T
+	t.Fatalf("%T %q not found", zero, name)
+	return zero
+}
+
+func findHostedManifest[T manifestObject](t *testing.T, manifests []runtime.Object, name, location string) T {
+	t.Helper()
+
+	for _, manifest := range manifests {
+		obj, ok := manifest.(T)
+		if ok && obj.GetName() == name && hostedLocation(obj) == location {
+			return obj
+		}
+	}
+
+	var zero T
+	t.Fatalf("%T %q with hosted location %q not found", zero, name, location)
+	return zero
+}
+
+func assertHostedManifestMissing[T manifestObject](t *testing.T, manifests []runtime.Object, name, location string) {
+	t.Helper()
+
+	for _, manifest := range manifests {
+		obj, ok := manifest.(T)
+		if ok && obj.GetName() == name && hostedLocation(obj) == location {
+			t.Fatalf("%T %q with hosted location %q should not be rendered", obj, name, location)
+		}
+	}
+}
+
+func hostedLocation(obj metav1.Object) string {
+	return obj.GetAnnotations()[addonv1beta1.HostedManifestLocationAnnotationKey]
+}
+
+func testProvisionerSourceRBACName(installNamespace string) string {
+	return fmt.Sprintf("managed-serviceaccount-kubeconfig-provisioner-source-%s", installNamespace)
+}
+
+func assertRule(t *testing.T, rules []rbacv1.PolicyRule, apiGroups, resources, verbs, resourceNames []string) {
+	t.Helper()
+
+	assert.Contains(t, rules, rbacv1.PolicyRule{
+		APIGroups:     apiGroups,
+		Resources:     resources,
+		Verbs:         verbs,
+		ResourceNames: resourceNames,
+	})
+}
+
+func assertRoleBindingBinds(t *testing.T, binding *rbacv1.RoleBinding, roleName, subjectName, subjectNamespace string) {
+	t.Helper()
+
+	assert.Equal(t, "Role", binding.RoleRef.Kind)
+	assert.Equal(t, roleName, binding.RoleRef.Name)
+	assert.Len(t, binding.Subjects, 1)
+	assert.Equal(t, "ServiceAccount", binding.Subjects[0].Kind)
+	assert.Equal(t, subjectName, binding.Subjects[0].Name)
+	assert.Equal(t, subjectNamespace, binding.Subjects[0].Namespace)
+}
+
+func findNamespaces(manifests []runtime.Object) []*corev1.Namespace {
+	namespaces := []*corev1.Namespace{}
+	for _, manifest := range manifests {
+		namespace, ok := manifest.(*corev1.Namespace)
+		if ok {
+			namespaces = append(namespaces, namespace)
+		}
+	}
+	return namespaces
+}
+
+func assertDeploymentSecretVolume(t *testing.T, deployment *appsv1.Deployment, volumeName, secretName string) {
+	t.Helper()
+
+	for _, volume := range deployment.Spec.Template.Spec.Volumes {
+		if volume.Name != volumeName {
+			continue
+		}
+		if assert.NotNil(t, volume.Secret, "volume %q should use a secret", volumeName) {
+			assert.Equal(t, secretName, volume.Secret.SecretName)
+		}
+		return
+	}
+	t.Fatalf("volume %q not found", volumeName)
+}
+
+func assertDeploymentMissingVolume(t *testing.T, deployment *appsv1.Deployment, volumeName string) {
+	t.Helper()
+
+	for _, volume := range deployment.Spec.Template.Spec.Volumes {
+		if volume.Name == volumeName {
+			t.Fatalf("volume %q should not be rendered", volumeName)
+		}
+	}
+}
+
+func assertDeploymentVolumeMount(t *testing.T, deployment *appsv1.Deployment, volumeName, mountPath string) {
+	t.Helper()
+
+	if !assert.NotEmpty(t, deployment.Spec.Template.Spec.Containers, "expected at least one container") {
+		return
+	}
+	for _, mount := range deployment.Spec.Template.Spec.Containers[0].VolumeMounts {
+		if mount.Name == volumeName {
+			assert.Equal(t, mountPath, mount.MountPath)
+			assert.True(t, mount.ReadOnly)
+			return
+		}
+	}
+	t.Fatalf("volume mount %q not found", volumeName)
+}
+
 func newTestImagePullSecret() *corev1.Secret {
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -684,6 +1505,15 @@ func newTestCluster(name string) *clusterv1.ManagedCluster {
 			Name: name,
 		},
 	}
+}
+
+func newTestHostedAddOn(name, namespace, hostingClusterName string) *addonv1beta1.ManagedClusterAddOn {
+	addon := newTestAddOn(name, namespace)
+	addon.Annotations = map[string]string{
+		addonv1beta1.HostingClusterNameAnnotationKey: hostingClusterName,
+		addonv1beta1.InstallNamespaceAnnotation:      name,
+	}
+	return addon
 }
 
 func newTestAddOn(name, namespace string) *addonv1beta1.ManagedClusterAddOn {

--- a/pkg/addon/manager/manifests/charts/managed-serviceaccount-agent/templates/_helpers.tpl
+++ b/pkg/addon/manager/manifests/charts/managed-serviceaccount-agent/templates/_helpers.tpl
@@ -1,0 +1,15 @@
+{{- define "managed-serviceaccount-agent.externalManagedKubeConfigNamespace" -}}
+{{- default .Values.clusterName .Values.externalManagedKubeConfigNamespace -}}
+{{- end -}}
+
+{{- define "managed-serviceaccount-agent.provisionerName" -}}
+managed-serviceaccount-kubeconfig-provisioner
+{{- end -}}
+
+{{- define "managed-serviceaccount-agent.provisionerSourceRBACName" -}}
+{{- printf "%s-source-%s" (include "managed-serviceaccount-agent.provisionerName" .) .Values.addonInstallNamespace -}}
+{{- end -}}
+
+{{- define "managed-serviceaccount-agent.hostingAgentServiceAccountName" -}}
+managed-serviceaccount
+{{- end -}}

--- a/pkg/addon/manager/manifests/charts/managed-serviceaccount-agent/templates/agent-networkpolicy.yaml
+++ b/pkg/addon/manager/manifests/charts/managed-serviceaccount-agent/templates/agent-networkpolicy.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.networkPolicies.enabled }}
-# Purpose: Default-deny for managed-serviceaccount-addon-agent on the managed
-# cluster, then allow required egress (DNS + hub/spoke API). Health ingress
+# Purpose: Default-deny for managed-serviceaccount-addon-agent on the cluster
+# where it runs, then allow required egress (DNS + hub/spoke API). Health ingress
 # (:8000) allows kubelet livenessProbe /healthz. Metrics ingress (:38080) is
 # allowed only when Prometheus is enabled. Peers are port-based (empty
 # "to"/"from") for portability across Kubernetes vendors. Enabled when the hub
@@ -12,6 +12,10 @@ kind: NetworkPolicy
 metadata:
   name: managed-serviceaccount-addon-agent-network-policy
   namespace: {{ .Values.addonInstallNamespace }}
+{{- if eq .Values.installMode "Hosted" }}
+  annotations:
+    addon.open-cluster-management.io/hosted-manifest-location: hosting
+{{- end }}
   labels:
     addon-agent: managed-serviceaccount
 spec:

--- a/pkg/addon/manager/manifests/charts/managed-serviceaccount-agent/templates/clusterrolebinding.yaml
+++ b/pkg/addon/manager/manifests/charts/managed-serviceaccount-agent/templates/clusterrolebinding.yaml
@@ -8,5 +8,5 @@ roleRef:
   name: open-cluster-management:managed-serviceaccount:addon-agent
 subjects:
   - kind: ServiceAccount
-    name: managed-serviceaccount
+    name: {{ .Values.managedServiceAccountName | quote }}
     namespace: {{ .Values.addonInstallNamespace }}

--- a/pkg/addon/manager/manifests/charts/managed-serviceaccount-agent/templates/deployment.yaml
+++ b/pkg/addon/manager/manifests/charts/managed-serviceaccount-agent/templates/deployment.yaml
@@ -4,6 +4,12 @@ kind: Deployment
 metadata:
   name: managed-serviceaccount-addon-agent
   namespace: {{ .Values.addonInstallNamespace }}
+  labels:
+    addon-agent: managed-serviceaccount
+{{- if eq .Values.installMode "Hosted" }}
+  annotations:
+    addon.open-cluster-management.io/hosted-manifest-location: hosting
+{{- end }}
 spec:
   replicas: 1
   selector:
@@ -14,7 +20,11 @@ spec:
       labels:
         addon-agent: managed-serviceaccount
     spec:
-      serviceAccountName: managed-serviceaccount
+{{- if eq .Values.installMode "Hosted" }}
+      serviceAccountName: {{ include "managed-serviceaccount-agent.hostingAgentServiceAccountName" . }}
+{{- else }}
+      serviceAccountName: {{ .Values.managedServiceAccountName | quote }}
+{{- end }}
       securityContext:
         runAsNonRoot: true
         seccompProfile:
@@ -38,10 +48,16 @@ spec:
           command:
             - /msa
             - agent
+          # Quote every templated argument so a value can never smuggle
+          # additional arguments into this container.
           args:
             - --leader-elect=false
-            - --cluster-name={{ .Values.clusterName }}
+            - {{ printf "--cluster-name=%v" .Values.clusterName | quote }}
+            - {{ printf "--install-mode=%v" .Values.installMode | quote }}
             - --kubeconfig=/etc/hub/kubeconfig
+{{- if eq .Values.installMode "Hosted" }}
+            - --spoke-kubeconfig=/etc/managed/kubeconfig
+{{- end }}
             - --lease-health-check=true
           ports:
             - name: metrics
@@ -51,6 +67,11 @@ spec:
             - name: hub-kubeconfig
               mountPath: /etc/hub/
               readOnly: true
+{{- if eq .Values.installMode "Hosted" }}
+            - name: managed-kubeconfig
+              mountPath: /etc/managed/
+              readOnly: true
+{{- end }}
           livenessProbe:
             httpGet:
               path: /healthz
@@ -60,7 +81,12 @@ spec:
       volumes:
         - name: hub-kubeconfig
           secret:
-            secretName: {{ .Values.hubKubeConfigSecret }}
+            secretName: {{ .Values.hubKubeConfigSecret | quote }}
+{{- if eq .Values.installMode "Hosted" }}
+        - name: managed-kubeconfig
+          secret:
+            secretName: {{ .Values.managedKubeConfigSecret | quote }}
+{{- end }}
 {{- if .Values.imagePullSecretData }}
       imagePullSecrets:
       - name: open-cluster-management-image-pull-credentials

--- a/pkg/addon/manager/manifests/charts/managed-serviceaccount-agent/templates/image_pull_secret.yaml
+++ b/pkg/addon/manager/manifests/charts/managed-serviceaccount-agent/templates/image_pull_secret.yaml
@@ -4,6 +4,10 @@ kind: Secret
 metadata:
   name: open-cluster-management-image-pull-credentials
   namespace: {{ .Values.addonInstallNamespace }}
+{{- if eq .Values.installMode "Hosted" }}
+  annotations:
+    addon.open-cluster-management.io/hosted-manifest-location: hosting
+{{- end }}
 type: kubernetes.io/dockerconfigjson
 data:
   ".dockerconfigjson": {{ .Values.imagePullSecretData }}

--- a/pkg/addon/manager/manifests/charts/managed-serviceaccount-agent/templates/lease_role_hosting.yaml
+++ b/pkg/addon/manager/manifests/charts/managed-serviceaccount-agent/templates/lease_role_hosting.yaml
@@ -1,0 +1,18 @@
+{{- if eq .Values.installMode "Hosted" }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: managed-serviceaccount-health-lease
+  namespace: {{ .Values.addonInstallNamespace }}
+  annotations:
+    addon.open-cluster-management.io/hosted-manifest-location: hosting
+rules:
+# Kubernetes RBAC cannot restrict create requests by resourceNames.
+- apiGroups: ["coordination.k8s.io"]
+  resources: ["leases"]
+  verbs: ["create"]
+- apiGroups: ["coordination.k8s.io"]
+  resources: ["leases"]
+  resourceNames: ["managed-serviceaccount"]
+  verbs: ["get", "update", "patch"]
+{{- end }}

--- a/pkg/addon/manager/manifests/charts/managed-serviceaccount-agent/templates/lease_rolebinding_hosting.yaml
+++ b/pkg/addon/manager/manifests/charts/managed-serviceaccount-agent/templates/lease_rolebinding_hosting.yaml
@@ -1,0 +1,17 @@
+{{- if eq .Values.installMode "Hosted" }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: managed-serviceaccount-health-lease
+  namespace: {{ .Values.addonInstallNamespace }}
+  annotations:
+    addon.open-cluster-management.io/hosted-manifest-location: hosting
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: managed-serviceaccount-health-lease
+subjects:
+- kind: ServiceAccount
+  name: {{ include "managed-serviceaccount-agent.hostingAgentServiceAccountName" . }}
+  namespace: {{ .Values.addonInstallNamespace }}
+{{- end }}

--- a/pkg/addon/manager/manifests/charts/managed-serviceaccount-agent/templates/metrics_service.yaml
+++ b/pkg/addon/manager/manifests/charts/managed-serviceaccount-agent/templates/metrics_service.yaml
@@ -3,6 +3,10 @@ kind: Service
 metadata:
   name: managed-serviceaccount-addon-agent
   namespace: {{ .Values.addonInstallNamespace }}
+{{- if eq .Values.installMode "Hosted" }}
+  annotations:
+    addon.open-cluster-management.io/hosted-manifest-location: hosting
+{{- end }}
   labels:
     addon-agent: managed-serviceaccount
 spec:

--- a/pkg/addon/manager/manifests/charts/managed-serviceaccount-agent/templates/namespace_hosting.yaml
+++ b/pkg/addon/manager/manifests/charts/managed-serviceaccount-agent/templates/namespace_hosting.yaml
@@ -1,0 +1,8 @@
+{{- if eq .Values.installMode "Hosted" }}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .Values.addonInstallNamespace }}
+  annotations:
+    addon.open-cluster-management.io/hosted-manifest-location: hosting
+{{- end }}

--- a/pkg/addon/manager/manifests/charts/managed-serviceaccount-agent/templates/provisioner_deployment.yaml
+++ b/pkg/addon/manager/manifests/charts/managed-serviceaccount-agent/templates/provisioner_deployment.yaml
@@ -1,0 +1,70 @@
+{{- if eq .Values.installMode "Hosted" }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "managed-serviceaccount-agent.provisionerName" . }}
+  namespace: {{ .Values.addonInstallNamespace }}
+  labels:
+    addon-agent: {{ include "managed-serviceaccount-agent.provisionerName" . }}
+  annotations:
+    addon.open-cluster-management.io/hosted-manifest-location: hosting
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      addon-agent: {{ include "managed-serviceaccount-agent.provisionerName" . }}
+  template:
+    metadata:
+      labels:
+        addon-agent: {{ include "managed-serviceaccount-agent.provisionerName" . }}
+    spec:
+      serviceAccountName: {{ include "managed-serviceaccount-agent.provisionerName" . }}
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+{{- if .Values.NodeSelector }}
+      nodeSelector: {{ toYaml .Values.NodeSelector | nindent 8 }}
+{{- end }}
+{{- if .Values.Tolerations }}
+      tolerations: {{ toYaml .Values.Tolerations | nindent 8 }}
+{{- end }}
+      containers:
+        - name: kubeconfig-provisioner
+          image: {{ include "managed-serviceaccount-common.agentImage" . }}
+          imagePullPolicy: IfNotPresent
+          {{- $containerID := printf "deployments:%s:%s" (include "managed-serviceaccount-agent.provisionerName" .) "kubeconfig-provisioner" }}
+          {{- range $item := reverse .Values.ResourceRequirements }}
+            {{- if regexMatch $item.ContainerIDRegex $containerID }}
+          resources:
+              {{- toYaml $item.Resources | nindent 12 }}
+              {{- break }}
+            {{- end }}
+          {{- end }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+              - ALL
+          command:
+            - /msa
+            - managed-kubeconfig-provisioner
+          # Quote every argument so a customized-variable value can never smuggle
+          # additional arguments into this container.
+          args:
+            - {{ printf "--source-namespace=%v" (include "managed-serviceaccount-agent.externalManagedKubeConfigNamespace" .) | quote }}
+            - {{ printf "--source-secret=%v" .Values.externalManagedKubeConfigSecret | quote }}
+            - {{ printf "--target-namespace=%v" .Values.addonInstallNamespace | quote }}
+            - {{ printf "--target-secret=%v" .Values.managedKubeConfigSecret | quote }}
+            - {{ printf "--managed-serviceaccount-namespace=%v" .Values.addonInstallNamespace | quote }}
+            - {{ printf "--managed-serviceaccount-name=%v" .Values.managedServiceAccountName | quote }}
+            - {{ printf "--hosting-service-account-name=%v" (include "managed-serviceaccount-agent.provisionerName" .) | quote }}
+            - {{ printf "--token-expiration-seconds=%v" .Values.managedKubeConfigTokenExpirationSeconds | quote }}
+            - {{ printf "--refresh-before=%v" .Values.managedKubeConfigRefreshBefore | quote }}
+            - {{ printf "--sync-interval=%v" .Values.managedKubeConfigProvisionerSyncInterval | quote }}
+{{- if .Values.imagePullSecretData }}
+      imagePullSecrets:
+      - name: open-cluster-management-image-pull-credentials
+{{- end }}
+{{- end }}

--- a/pkg/addon/manager/manifests/charts/managed-serviceaccount-agent/templates/provisioner_networkpolicy.yaml
+++ b/pkg/addon/manager/manifests/charts/managed-serviceaccount-agent/templates/provisioner_networkpolicy.yaml
@@ -1,0 +1,36 @@
+{{- if and (eq .Values.installMode "Hosted") .Values.networkPolicies.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "managed-serviceaccount-agent.provisionerName" . }}-network-policy
+  namespace: {{ .Values.addonInstallNamespace }}
+  annotations:
+    addon.open-cluster-management.io/hosted-manifest-location: hosting
+  labels:
+    addon-agent: {{ include "managed-serviceaccount-agent.provisionerName" . }}
+spec:
+  podSelector:
+    matchLabels:
+      addon-agent: {{ include "managed-serviceaccount-agent.provisionerName" . }}
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress: []
+  egress:
+  # DNS (:53 common; :5353 used by some distributions)
+  - ports:
+    - protocol: UDP
+      port: 53
+    - protocol: TCP
+      port: 53
+    - protocol: UDP
+      port: 5353
+    - protocol: TCP
+      port: 5353
+  # Hosting and managed-cluster Kubernetes APIs
+  - ports:
+    - protocol: TCP
+      port: 443
+    - protocol: TCP
+      port: 6443
+{{- end }}

--- a/pkg/addon/manager/manifests/charts/managed-serviceaccount-agent/templates/provisioner_role.yaml
+++ b/pkg/addon/manager/manifests/charts/managed-serviceaccount-agent/templates/provisioner_role.yaml
@@ -1,0 +1,27 @@
+{{- if eq .Values.installMode "Hosted" }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "managed-serviceaccount-agent.provisionerName" . }}
+  namespace: {{ .Values.addonInstallNamespace }}
+  annotations:
+    addon.open-cluster-management.io/hosted-manifest-location: hosting
+rules:
+# Kubernetes RBAC cannot restrict create requests by resourceNames. A hosted
+# agent therefore requires a dedicated addon install namespace per managed
+# cluster.
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["create"]
+- apiGroups: [""]
+  resources: ["secrets"]
+  resourceNames: [{{ .Values.managedKubeConfigSecret | quote }}]
+  verbs: ["get", "update"]
+- apiGroups: [""]
+  resources: ["serviceaccounts"]
+  resourceNames: ["{{ include "managed-serviceaccount-agent.provisionerName" . }}"]
+  verbs: ["get"]
+- apiGroups: ["events.k8s.io"]
+  resources: ["events"]
+  verbs: ["create", "patch", "update"]
+{{- end }}

--- a/pkg/addon/manager/manifests/charts/managed-serviceaccount-agent/templates/provisioner_rolebinding.yaml
+++ b/pkg/addon/manager/manifests/charts/managed-serviceaccount-agent/templates/provisioner_rolebinding.yaml
@@ -1,0 +1,17 @@
+{{- if eq .Values.installMode "Hosted" }}
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "managed-serviceaccount-agent.provisionerName" . }}
+  namespace: {{ .Values.addonInstallNamespace }}
+  annotations:
+    addon.open-cluster-management.io/hosted-manifest-location: hosting
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "managed-serviceaccount-agent.provisionerName" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "managed-serviceaccount-agent.provisionerName" . }}
+    namespace: {{ .Values.addonInstallNamespace }}
+{{- end }}

--- a/pkg/addon/manager/manifests/charts/managed-serviceaccount-agent/templates/provisioner_serviceaccount.yaml
+++ b/pkg/addon/manager/manifests/charts/managed-serviceaccount-agent/templates/provisioner_serviceaccount.yaml
@@ -1,0 +1,9 @@
+{{- if eq .Values.installMode "Hosted" }}
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: {{ include "managed-serviceaccount-agent.provisionerName" . }}
+  namespace: {{ .Values.addonInstallNamespace }}
+  annotations:
+    addon.open-cluster-management.io/hosted-manifest-location: hosting
+{{- end }}

--- a/pkg/addon/manager/manifests/charts/managed-serviceaccount-agent/templates/provisioner_source_role.yaml
+++ b/pkg/addon/manager/manifests/charts/managed-serviceaccount-agent/templates/provisioner_source_role.yaml
@@ -1,0 +1,14 @@
+{{- if eq .Values.installMode "Hosted" }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "managed-serviceaccount-agent.provisionerSourceRBACName" . }}
+  namespace: {{ include "managed-serviceaccount-agent.externalManagedKubeConfigNamespace" . | quote }}
+  annotations:
+    addon.open-cluster-management.io/hosted-manifest-location: hosting
+rules:
+- apiGroups: [""]
+  resources: ["secrets"]
+  resourceNames: [{{ .Values.externalManagedKubeConfigSecret | quote }}]
+  verbs: ["get"]
+{{- end }}

--- a/pkg/addon/manager/manifests/charts/managed-serviceaccount-agent/templates/provisioner_source_rolebinding.yaml
+++ b/pkg/addon/manager/manifests/charts/managed-serviceaccount-agent/templates/provisioner_source_rolebinding.yaml
@@ -1,0 +1,17 @@
+{{- if eq .Values.installMode "Hosted" }}
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "managed-serviceaccount-agent.provisionerSourceRBACName" . }}
+  namespace: {{ include "managed-serviceaccount-agent.externalManagedKubeConfigNamespace" . | quote }}
+  annotations:
+    addon.open-cluster-management.io/hosted-manifest-location: hosting
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "managed-serviceaccount-agent.provisionerSourceRBACName" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "managed-serviceaccount-agent.provisionerName" . }}
+    namespace: {{ .Values.addonInstallNamespace }}
+{{- end }}

--- a/pkg/addon/manager/manifests/charts/managed-serviceaccount-agent/templates/role.yaml
+++ b/pkg/addon/manager/manifests/charts/managed-serviceaccount-agent/templates/role.yaml
@@ -13,9 +13,11 @@ rules:
 - apiGroups: [""]
   resources: ["serviceaccounts", "serviceaccounts/token"]
   verbs: ["get", "watch", "list", "create", "delete"]
+{{- if ne .Values.installMode "Hosted" }}
 - apiGroups: ["coordination.k8s.io"]
   resources: ["leases"]
   verbs: ["get", "create", "update", "patch"]
+{{- end }}
 - apiGroups: ["authentication.k8s.io"]
   resources: ["tokenrequests"]
   verbs: ["get", "create", "update", "patch"]

--- a/pkg/addon/manager/manifests/charts/managed-serviceaccount-agent/templates/rolebinding.yaml
+++ b/pkg/addon/manager/manifests/charts/managed-serviceaccount-agent/templates/rolebinding.yaml
@@ -9,5 +9,5 @@ roleRef:
   name: open-cluster-management:managed-serviceaccount:addon-agent
 subjects:
   - kind: ServiceAccount
-    name: managed-serviceaccount
+    name: {{ .Values.managedServiceAccountName | quote }}
     namespace: {{ .Values.addonInstallNamespace }}

--- a/pkg/addon/manager/manifests/charts/managed-serviceaccount-agent/templates/service_monitor.yaml
+++ b/pkg/addon/manager/manifests/charts/managed-serviceaccount-agent/templates/service_monitor.yaml
@@ -4,6 +4,10 @@ kind: ServiceMonitor
 metadata:
   name: managed-serviceaccount-addon-agent
   namespace: {{ .Values.addonInstallNamespace }}
+{{- if eq .Values.installMode "Hosted" }}
+  annotations:
+    addon.open-cluster-management.io/hosted-manifest-location: hosting
+{{- end }}
 {{- with .Values.Prometheus.ServiceMonitor.Labels }}
   labels:
 {{- range $key, $value := . }}

--- a/pkg/addon/manager/manifests/charts/managed-serviceaccount-agent/templates/serviceaccount.yaml
+++ b/pkg/addon/manager/manifests/charts/managed-serviceaccount-agent/templates/serviceaccount.yaml
@@ -1,5 +1,5 @@
 kind: ServiceAccount
 apiVersion: v1
 metadata:
-  name: managed-serviceaccount
+  name: {{ .Values.managedServiceAccountName | quote }}
   namespace: {{ .Values.addonInstallNamespace }}

--- a/pkg/addon/manager/manifests/charts/managed-serviceaccount-agent/templates/serviceaccount_hosting.yaml
+++ b/pkg/addon/manager/manifests/charts/managed-serviceaccount-agent/templates/serviceaccount_hosting.yaml
@@ -1,0 +1,9 @@
+{{- if eq .Values.installMode "Hosted" }}
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: {{ include "managed-serviceaccount-agent.hostingAgentServiceAccountName" . }}
+  namespace: {{ .Values.addonInstallNamespace }}
+  annotations:
+    addon.open-cluster-management.io/hosted-manifest-location: hosting
+{{- end }}

--- a/pkg/addon/manager/manifests/charts/managed-serviceaccount-agent/values.yaml
+++ b/pkg/addon/manager/manifests/charts/managed-serviceaccount-agent/values.yaml
@@ -10,8 +10,23 @@ imagePullSecretData: ""
 clusterName: local-cluster
 addonInstallNamespace: open-cluster-management-agent-addon
 hubKubeConfigSecret: managed-serviceaccount-hub-kubeconfig
+managedKubeConfigSecret: managed-serviceaccount-managed-kubeconfig
+installMode: Default
 NodeSelector: {}
 Tolerations: []
+ResourceRequirements: []
+
+# Managed-cluster service account name, used in both install modes and
+# overridable per cluster through AddOnDeploymentConfig.spec.customizedVariables.
+managedServiceAccountName: managed-serviceaccount
+
+# Hosted-mode defaults, overridable per cluster through
+# AddOnDeploymentConfig.spec.customizedVariables.
+externalManagedKubeConfigNamespace: ""
+externalManagedKubeConfigSecret: external-managed-kubeconfig
+managedKubeConfigTokenExpirationSeconds: 3600
+managedKubeConfigRefreshBefore: 10m
+managedKubeConfigProvisionerSyncInterval: 5m
 
 Prometheus:
   Enabled: false

--- a/pkg/addon/manager/placement.go
+++ b/pkg/addon/manager/placement.go
@@ -1,0 +1,177 @@
+package manager
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"open-cluster-management.io/addon-framework/pkg/addonfactory"
+	addonconstants "open-cluster-management.io/addon-framework/pkg/addonmanager/constants"
+	"open-cluster-management.io/addon-framework/pkg/agent"
+	addonv1beta1 "open-cluster-management.io/api/addon/v1beta1"
+)
+
+const addonPlacementIndexName = "managed-serviceaccount-agent-cluster"
+
+// SetupAgentInstallNamespaceResolver indexes addons by the cluster where their agent
+// runs and returns an install namespace resolver that rejects a namespace already
+// claimed by another instance of the same addon on that cluster.
+func SetupAgentInstallNamespaceResolver(
+	ctx context.Context,
+	addonCache cache.Cache,
+	resolve agent.AgentInstallNamespaceFunc,
+) (agent.AgentInstallNamespaceFunc, error) {
+	if err := addonCache.IndexField(
+		ctx,
+		&addonv1beta1.ManagedClusterAddOn{},
+		addonPlacementIndexName,
+		indexAddonPlacement,
+	); err != nil {
+		return nil, fmt.Errorf("failed to index managed cluster addon placement: %w", err)
+	}
+	return uniqueAgentInstallNamespace(addonCache, resolve), nil
+}
+
+func uniqueAgentInstallNamespace(
+	addonReader client.Reader,
+	resolve agent.AgentInstallNamespaceFunc,
+) agent.AgentInstallNamespaceFunc {
+	return func(ctx context.Context, addon *addonv1beta1.ManagedClusterAddOn) (string, error) {
+		installNamespace, err := resolve(ctx, addon)
+		if err != nil {
+			return "", err
+		}
+
+		effectiveInstallNamespace := effectiveAgentInstallNamespace(addon, installNamespace)
+		if err := validateAgentInstallNamespace(addon, effectiveInstallNamespace); err != nil {
+			return "", err
+		}
+
+		// The addon-framework registration controller replaces Status.Namespace
+		// on the object copy passed to this resolver. Read the persisted object so
+		// an existing placement remains authoritative during registration.
+		persistedAddon := &addonv1beta1.ManagedClusterAddOn{}
+		if err := addonReader.Get(ctx, client.ObjectKeyFromObject(addon), persistedAddon); err != nil {
+			return "", fmt.Errorf(
+				"failed to validate addon install namespace %q for %s/%s: failed to read persisted addon: %w",
+				effectiveInstallNamespace, addon.Namespace, addon.Name, err,
+			)
+		}
+
+		agentClusterName := addonAgentCluster(addon)
+		addons := &addonv1beta1.ManagedClusterAddOnList{}
+		if err := addonReader.List(ctx, addons, client.MatchingFields{
+			addonPlacementIndexName: addonPlacementIndexKey(agentClusterName, addon.Name),
+		}); err != nil {
+			return "", fmt.Errorf("failed to validate addon install namespace %q: %w", effectiveInstallNamespace, err)
+		}
+
+		for i := range addons.Items {
+			other := &addons.Items[i]
+			if other.Namespace == addon.Namespace && other.Name == addon.Name {
+				continue
+			}
+
+			// status.namespace is the peer's current placement. Keep treating it
+			// as a claim even when a new configuration resolves elsewhere and the
+			// old hosting resources have not been removed yet.
+			otherClaimsNamespace := other.Status.Namespace == effectiveInstallNamespace
+			otherInstallNamespace, err := resolve(ctx, other)
+			if err != nil {
+				if len(other.Status.Namespace) == 0 {
+					// An undeployed peer that cannot resolve fails its own
+					// reconcile and reports its own status; do not let it
+					// block this addon.
+					klog.Warningf("skipping addon %s/%s while validating install namespace %q for %s/%s: %v",
+						other.Namespace, other.Name, effectiveInstallNamespace, addon.Namespace, addon.Name, err)
+				}
+			} else {
+				otherEffectiveNamespace := effectiveAgentInstallNamespace(other, otherInstallNamespace)
+				if err := validateAgentInstallNamespace(other, otherEffectiveNamespace); err != nil {
+					// Preserve an invalid peer's current status claim, but do not let
+					// an undeployed desired placement reserve the Default namespace.
+					klog.V(4).InfoS("Ignoring invalid desired addon install namespace",
+						"addonNamespace", other.Namespace, "addonName", other.Name, "err", err)
+				} else if otherEffectiveNamespace == effectiveInstallNamespace {
+					otherClaimsNamespace = true
+				}
+			}
+			if !otherClaimsNamespace {
+				continue
+			}
+			if claimPrecedes(persistedAddon, other, effectiveInstallNamespace) {
+				continue
+			}
+			return "", fmt.Errorf(
+				"addon %s/%s cannot use install namespace %q on agent cluster %q: already used by %s/%s",
+				addon.Namespace, addon.Name, effectiveInstallNamespace, agentClusterName, other.Namespace, other.Name,
+			)
+		}
+
+		return installNamespace, nil
+	}
+}
+
+// claimPrecedes reports whether addon claims the contested install namespace
+// ahead of other. An addon already holding the namespace in status.namespace
+// beats one that merely wants it, so reconfiguring another addon onto a live
+// claim is rejected; when neither or both hold it, the older addon wins, and
+// UID breaks ties deterministically. Distinct persisted Kubernetes objects
+// cannot have the same UID.
+func claimPrecedes(addon, other *addonv1beta1.ManagedClusterAddOn, namespace string) bool {
+	addonOccupies := addon.Status.Namespace == namespace
+	if otherOccupies := other.Status.Namespace == namespace; addonOccupies != otherOccupies {
+		return addonOccupies
+	}
+	if !addon.CreationTimestamp.Equal(&other.CreationTimestamp) {
+		return addon.CreationTimestamp.Before(&other.CreationTimestamp)
+	}
+	return addon.UID < other.UID
+}
+
+func indexAddonPlacement(obj client.Object) []string {
+	addon, ok := obj.(*addonv1beta1.ManagedClusterAddOn)
+	if !ok {
+		return nil
+	}
+	return []string{addonPlacementIndexKey(addonAgentCluster(addon), addon.Name)}
+}
+
+func addonPlacementIndexKey(agentClusterName, addonName string) string {
+	return agentClusterName + "/" + addonName
+}
+
+func addonAgentCluster(addon *addonv1beta1.ManagedClusterAddOn) string {
+	installMode, hostingClusterName := addonconstants.GetHostedModeInfo(addon, nil)
+	if installMode == addonconstants.InstallModeHosted {
+		return hostingClusterName
+	}
+	return addon.Namespace
+}
+
+func validateAgentInstallNamespace(addon *addonv1beta1.ManagedClusterAddOn, namespace string) error {
+	installMode, _ := addonconstants.GetHostedModeInfo(addon, nil)
+	if installMode == addonconstants.InstallModeHosted && namespace == addonfactory.AddonDefaultInstallNamespace {
+		return fmt.Errorf(
+			"hosted addon %s/%s must use a dedicated install namespace on agent cluster %q instead of %q",
+			addon.Namespace, addon.Name, addonAgentCluster(addon), addonfactory.AddonDefaultInstallNamespace,
+		)
+	}
+	return nil
+}
+
+// effectiveAgentInstallNamespace mirrors how the addon-framework resolves the agent
+// install namespace when rendering, so uniqueness is checked against the namespace
+// the agent actually lands in.
+func effectiveAgentInstallNamespace(addon *addonv1beta1.ManagedClusterAddOn, configuredNamespace string) string {
+	if len(configuredNamespace) > 0 {
+		return configuredNamespace
+	}
+	if installNamespace := addon.Annotations[addonv1beta1.InstallNamespaceAnnotation]; len(installNamespace) > 0 {
+		return installNamespace
+	}
+	return addonfactory.AddonDefaultInstallNamespace
+}

--- a/pkg/addon/manager/placement_test.go
+++ b/pkg/addon/manager/placement_test.go
@@ -1,0 +1,230 @@
+package manager
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"open-cluster-management.io/addon-framework/pkg/addonfactory"
+	"open-cluster-management.io/addon-framework/pkg/agent"
+	addonv1beta1 "open-cluster-management.io/api/addon/v1beta1"
+	"open-cluster-management.io/managed-serviceaccount/pkg/common"
+)
+
+func TestUniqueAgentInstallNamespace(t *testing.T) {
+	testScheme := runtime.NewScheme()
+	assert.NoError(t, addonv1beta1.Install(testScheme))
+
+	const configuredNamespaceAnnotation = "test.open-cluster-management.io/install-namespace"
+	const resolveFailureAnnotation = "test.open-cluster-management.io/resolve-failure"
+	resolve := agent.AgentInstallNamespaceFunc(func(_ context.Context, addon *addonv1beta1.ManagedClusterAddOn) (string, error) {
+		if message, ok := addon.Annotations[resolveFailureAnnotation]; ok {
+			return "", errors.New(message)
+		}
+		return addon.Annotations[configuredNamespaceAnnotation], nil
+	})
+
+	newAddon := func(clusterName, hostingClusterName, installNamespace string) *addonv1beta1.ManagedClusterAddOn {
+		addon := newTestAddOn(common.AddonName, clusterName)
+		addon.Annotations = map[string]string{}
+		if len(hostingClusterName) > 0 {
+			addon.Annotations[addonv1beta1.HostingClusterNameAnnotationKey] = hostingClusterName
+		}
+		if len(installNamespace) > 0 {
+			addon.Annotations[configuredNamespaceAnnotation] = installNamespace
+		}
+		return addon
+	}
+
+	withInstallNamespaceAnnotation := func(addon *addonv1beta1.ManagedClusterAddOn, namespace string) *addonv1beta1.ManagedClusterAddOn {
+		addon.Annotations[addonv1beta1.InstallNamespaceAnnotation] = namespace
+		return addon
+	}
+
+	baseTime := time.Date(2026, 5, 13, 0, 0, 0, 0, time.UTC)
+	createdAt := func(addon *addonv1beta1.ManagedClusterAddOn, offset time.Duration) *addonv1beta1.ManagedClusterAddOn {
+		addon.CreationTimestamp = metav1.NewTime(baseTime.Add(offset))
+		return addon
+	}
+	withUID := func(addon *addonv1beta1.ManagedClusterAddOn, uid string) *addonv1beta1.ManagedClusterAddOn {
+		addon.UID = types.UID(uid)
+		return addon
+	}
+	withResolveFailure := func(addon *addonv1beta1.ManagedClusterAddOn, message string) *addonv1beta1.ManagedClusterAddOn {
+		addon.Annotations[resolveFailureAnnotation] = message
+		return addon
+	}
+	withStatusNamespace := func(addon *addonv1beta1.ManagedClusterAddOn, namespace string) *addonv1beta1.ManagedClusterAddOn {
+		addon.Status.Namespace = namespace
+		return addon
+	}
+
+	cases := []struct {
+		name              string
+		current           *addonv1beta1.ManagedClusterAddOn
+		others            []*addonv1beta1.ManagedClusterAddOn
+		inputStatus       *string
+		omitCurrent       bool
+		expectedNamespace string
+		expectedError     string
+	}{
+		{
+			name:              "non-hosted addon preserves the configured namespace",
+			current:           newAddon("cluster1", "", "shared"),
+			expectedNamespace: "shared",
+		},
+		{
+			name:              "unique hosted namespace",
+			current:           newAddon("cluster1", "hosting1", "cluster1-addon"),
+			others:            []*addonv1beta1.ManagedClusterAddOn{newAddon("cluster2", "hosting1", "cluster2-addon")},
+			expectedNamespace: "cluster1-addon",
+		},
+		{
+			name:              "same namespace on another hosting cluster",
+			current:           newAddon("cluster1", "hosting1", "shared"),
+			others:            []*addonv1beta1.ManagedClusterAddOn{newAddon("cluster2", "hosting2", "shared")},
+			expectedNamespace: "shared",
+		},
+		{
+			name:          "duplicate explicit hosted namespace rejects the newer addon",
+			current:       createdAt(newAddon("cluster1", "hosting1", "shared"), time.Hour),
+			others:        []*addonv1beta1.ManagedClusterAddOn{createdAt(newAddon("cluster2", "hosting1", "shared"), 0)},
+			expectedError: `addon cluster1/managed-serviceaccount cannot use install namespace "shared" on agent cluster "hosting1": already used by cluster2/managed-serviceaccount`,
+		},
+		{
+			name:          "hosted addon requires a dedicated namespace",
+			current:       newAddon("cluster1", "hosting1", ""),
+			expectedError: `hosted addon cluster1/managed-serviceaccount must use a dedicated install namespace on agent cluster "hosting1" instead of "` + addonfactory.AddonDefaultInstallNamespace + `"`,
+		},
+		{
+			name:              "older addon keeps a contested namespace",
+			current:           createdAt(newAddon("cluster1", "hosting1", "shared"), 0),
+			others:            []*addonv1beta1.ManagedClusterAddOn{createdAt(newAddon("cluster2", "hosting1", "shared"), time.Hour)},
+			expectedNamespace: "shared",
+		},
+		{
+			name:          "uid breaks a creation timestamp tie",
+			current:       withUID(createdAt(newAddon("cluster1", "hosting1", "shared"), 0), "uid-b"),
+			others:        []*addonv1beta1.ManagedClusterAddOn{withUID(createdAt(newAddon("cluster2", "hosting1", "shared"), 0), "uid-a")},
+			expectedError: `addon cluster1/managed-serviceaccount cannot use install namespace "shared" on agent cluster "hosting1": already used by cluster2/managed-serviceaccount`,
+		},
+		{
+			name:              "a running incumbent keeps a namespace claimed by an older addon",
+			current:           createdAt(withStatusNamespace(newAddon("cluster1", "hosting1", "shared"), "shared"), time.Hour),
+			others:            []*addonv1beta1.ManagedClusterAddOn{createdAt(withStatusNamespace(newAddon("cluster2", "hosting1", "shared"), "cluster2-old"), 0)},
+			expectedNamespace: "shared",
+		},
+		{
+			name:              "registration input uses the persisted self namespace claim",
+			current:           createdAt(withStatusNamespace(newAddon("cluster1", "hosting1", "shared"), "shared"), time.Hour),
+			others:            []*addonv1beta1.ManagedClusterAddOn{createdAt(withStatusNamespace(newAddon("cluster2", "hosting1", "shared"), "cluster2-old"), 0)},
+			inputStatus:       ptr.To(addonfactory.AddonDefaultInstallNamespace),
+			expectedNamespace: "shared",
+		},
+		{
+			name:          "an older addon reconfigured onto an occupied namespace is rejected",
+			current:       createdAt(withStatusNamespace(newAddon("cluster1", "hosting1", "shared"), "cluster1-old"), 0),
+			others:        []*addonv1beta1.ManagedClusterAddOn{createdAt(withStatusNamespace(newAddon("cluster2", "hosting1", "shared"), "shared"), time.Hour)},
+			expectedError: `addon cluster1/managed-serviceaccount cannot use install namespace "shared" on agent cluster "hosting1": already used by cluster2/managed-serviceaccount`,
+		},
+		{
+			name:    "a peer moving away still defends its current namespace",
+			current: createdAt(newAddon("cluster1", "hosting1", "shared"), 0),
+			others: []*addonv1beta1.ManagedClusterAddOn{
+				createdAt(withStatusNamespace(newAddon("cluster2", "hosting1", "cluster2-new"), "shared"), time.Hour),
+			},
+			expectedError: `addon cluster1/managed-serviceaccount cannot use install namespace "shared" on agent cluster "hosting1": already used by cluster2/managed-serviceaccount`,
+		},
+		{
+			name:              "skips undeployed peers that fail to resolve",
+			current:           newAddon("cluster1", "hosting1", "cluster1-addon"),
+			others:            []*addonv1beta1.ManagedClusterAddOn{withResolveFailure(newAddon("cluster2", "hosting1", "cluster1-addon"), "deployment config not found")},
+			expectedNamespace: "cluster1-addon",
+		},
+		{
+			name:    "a deployed peer that fails to resolve still defends its namespace",
+			current: createdAt(newAddon("cluster1", "hosting1", "cluster2-addon"), time.Hour),
+			others: []*addonv1beta1.ManagedClusterAddOn{
+				withResolveFailure(withStatusNamespace(createdAt(newAddon("cluster2", "hosting1", ""), 0), "cluster2-addon"), "deployment config not found"),
+			},
+			expectedError: `addon cluster1/managed-serviceaccount cannot use install namespace "cluster2-addon" on agent cluster "hosting1": already used by cluster2/managed-serviceaccount`,
+		},
+		{
+			name:              "install namespace annotation only collides with the same annotation",
+			current:           withInstallNamespaceAnnotation(newAddon("cluster1", "hosting1", ""), "annotated"),
+			others:            []*addonv1beta1.ManagedClusterAddOn{newAddon("cluster2", "hosting1", "")},
+			expectedNamespace: "",
+		},
+		{
+			name:          "duplicate hosted namespace from the install namespace annotation",
+			current:       createdAt(withInstallNamespaceAnnotation(newAddon("cluster1", "hosting1", ""), "annotated"), time.Hour),
+			others:        []*addonv1beta1.ManagedClusterAddOn{createdAt(withInstallNamespaceAnnotation(newAddon("cluster2", "hosting1", ""), "annotated"), 0)},
+			expectedError: `addon cluster1/managed-serviceaccount cannot use install namespace "annotated" on agent cluster "hosting1": already used by cluster2/managed-serviceaccount`,
+		},
+		{
+			name:          "hosted addon cannot explicitly select the default namespace",
+			current:       withInstallNamespaceAnnotation(newAddon("cluster1", "hosting1", ""), addonfactory.AddonDefaultInstallNamespace),
+			expectedError: `hosted addon cluster1/managed-serviceaccount must use a dedicated install namespace on agent cluster "hosting1" instead of "` + addonfactory.AddonDefaultInstallNamespace + `"`,
+		},
+		{
+			name:              "default addon ignores an invalid undeployed hosted peer",
+			current:           createdAt(newAddon("hosting1", "", ""), time.Hour),
+			others:            []*addonv1beta1.ManagedClusterAddOn{createdAt(newAddon("cluster1", "hosting1", ""), 0)},
+			expectedNamespace: "",
+		},
+		{
+			name:          "default addon preserves a deployed hosted peer claim",
+			current:       createdAt(newAddon("hosting1", "", ""), time.Hour),
+			others:        []*addonv1beta1.ManagedClusterAddOn{createdAt(withStatusNamespace(newAddon("cluster1", "hosting1", ""), addonfactory.AddonDefaultInstallNamespace), 0)},
+			expectedError: `addon hosting1/managed-serviceaccount cannot use install namespace "` + addonfactory.AddonDefaultInstallNamespace + `" on agent cluster "hosting1": already used by cluster1/managed-serviceaccount`,
+		},
+		{
+			name:          "fails closed while the persisted self is absent from the cache",
+			current:       newAddon("cluster1", "hosting1", "shared"),
+			omitCurrent:   true,
+			expectedError: `failed to validate addon install namespace "shared" for cluster1/managed-serviceaccount: failed to read persisted addon: managedclusteraddons.addon.open-cluster-management.io "managed-serviceaccount" not found`,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			objects := make([]client.Object, 0, len(c.others)+1)
+			cachedAddons := append([]*addonv1beta1.ManagedClusterAddOn(nil), c.others...)
+			if !c.omitCurrent {
+				cachedAddons = append(cachedAddons, c.current)
+			}
+			for _, addon := range cachedAddons {
+				objects = append(objects, addon)
+			}
+			addonReader := fakeclient.NewClientBuilder().
+				WithScheme(testScheme).
+				WithIndex(&addonv1beta1.ManagedClusterAddOn{}, addonPlacementIndexName, indexAddonPlacement).
+				WithObjects(objects...).
+				Build()
+			resolveUnique := uniqueAgentInstallNamespace(addonReader, resolve)
+			input := c.current.DeepCopy()
+			if c.inputStatus != nil {
+				input.Status.Namespace = *c.inputStatus
+			}
+
+			namespace, err := resolveUnique(context.Background(), input)
+
+			if len(c.expectedError) > 0 {
+				assert.EqualError(t, err, c.expectedError)
+				assert.Empty(t, namespace)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, c.expectedNamespace, namespace)
+		})
+	}
+}

--- a/pkg/addon/provisioner/provisioner.go
+++ b/pkg/addon/provisioner/provisioner.go
@@ -1,0 +1,601 @@
+package provisioner
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"strconv"
+	"time"
+
+	"github.com/pkg/errors"
+	authenticationv1 "k8s.io/api/authentication/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	kevents "k8s.io/client-go/tools/events"
+	"k8s.io/klog/v2"
+	"k8s.io/utils/clock"
+	"k8s.io/utils/ptr"
+)
+
+const (
+	KubeconfigSecretKey                = "kubeconfig"
+	ManagedServiceAccountUIDAnnotation = "authentication.open-cluster-management.io/managed-serviceaccount-uid"
+
+	DefaultExternalManagedKubeConfigSecret = "external-managed-kubeconfig"
+	DefaultManagedServiceAccountName       = "managed-serviceaccount"
+	DefaultHostingServiceAccountName       = "managed-serviceaccount-kubeconfig-provisioner"
+	DefaultTokenExpirationSeconds          = int64(3600)
+	DefaultRefreshBefore                   = 10 * time.Minute
+	DefaultSyncInterval                    = 5 * time.Minute
+	DefaultRequestTimeout                  = 30 * time.Second
+	minTokenExpirationSeconds              = int64(10 * 60)
+	maxTokenExpirationSeconds              = int64(1 << 32)
+)
+
+const (
+	tokenExpirationKey   = "expirationTimestamp"
+	managedTokenFilePath = "/etc/managed/token"
+
+	tokenExpirationAnnotation                = "authentication.open-cluster-management.io/token-expiration"
+	sourceKubeconfigHashAnnotation           = "authentication.open-cluster-management.io/source-kubeconfig-hash"
+	managedServiceAccountNamespaceAnnotation = "authentication.open-cluster-management.io/managed-serviceaccount-namespace"
+	managedServiceAccountNameAnnotation      = "authentication.open-cluster-management.io/managed-serviceaccount-name"
+	tokenExpirationSecondsAnnotation         = "authentication.open-cluster-management.io/token-expiration-seconds"
+
+	initialErrorBackoff = time.Second
+	maxErrorBackoff     = time.Minute
+
+	managedKubeconfigSecretOwnershipConflictReason = "ManagedKubeconfigSecretOwnershipConflict"
+	provisioningBlockedAction                      = "ProvisioningBlocked"
+)
+
+// Result describes when the provisioner must next reconcile to refresh a
+// generated token before it expires.
+type Result struct {
+	RequeueAfter time.Duration
+}
+
+type retryAfterError struct {
+	err   error
+	after time.Duration
+}
+
+func (e *retryAfterError) Error() string {
+	return e.err.Error()
+}
+
+func (e *retryAfterError) Unwrap() error {
+	return e.err
+}
+
+type ManagedClientFactory func(sourceConfig *clientcmdapi.Config) (kubernetes.Interface, error)
+
+type Provisioner struct {
+	HostingClient kubernetes.Interface
+	EventRecorder kevents.EventRecorder
+
+	SourceNamespace string
+	SourceSecret    string
+	TargetNamespace string
+	TargetSecret    string
+
+	ManagedServiceAccountNamespace string
+	ManagedServiceAccountName      string
+	HostingServiceAccountName      string
+	TokenExpirationSeconds         int64
+	RefreshBefore                  time.Duration
+	SyncInterval                   time.Duration
+
+	ManagedClientFactory ManagedClientFactory
+	Clock                clock.Clock
+}
+
+// ValidateRotationSettings validates the token lifetime and reconcile timing
+// shared by the addon renderer and the provisioner process.
+func ValidateRotationSettings(tokenExpirationSeconds int64, refreshBefore, syncInterval time.Duration) error {
+	if tokenExpirationSeconds < minTokenExpirationSeconds || tokenExpirationSeconds > maxTokenExpirationSeconds {
+		return errors.Errorf("token expiration seconds must be between %d and %d, got %d",
+			minTokenExpirationSeconds, maxTokenExpirationSeconds, tokenExpirationSeconds)
+	}
+	if refreshBefore <= 0 {
+		return errors.Errorf("refresh before must be a positive duration, got %s", refreshBefore)
+	}
+	if syncInterval <= 0 {
+		return errors.Errorf("sync interval must be a positive duration, got %s", syncInterval)
+	}
+
+	tokenLifetime := time.Duration(tokenExpirationSeconds) * time.Second
+	if refreshBefore >= tokenLifetime {
+		return errors.Errorf("refresh before (%s) must be less than the token lifetime (%s)", refreshBefore, tokenLifetime)
+	}
+	return nil
+}
+
+func newManagedClient(sourceConfig *clientcmdapi.Config) (kubernetes.Interface, error) {
+	cfg, err := clientcmd.NewDefaultClientConfig(*sourceConfig, &clientcmd.ConfigOverrides{}).ClientConfig()
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to build managed client config from source kubeconfig")
+	}
+	if cfg.Timeout == 0 {
+		cfg.Timeout = DefaultRequestTimeout
+	}
+
+	client, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to create managed client from source kubeconfig")
+	}
+	return client, nil
+}
+
+// Start reconciles until ctx is done. Complete must be called first.
+func (p *Provisioner) Start(ctx context.Context) error {
+	return runReconcile(ctx, p.Sync, p.SyncInterval)
+}
+
+func runReconcile(ctx context.Context, sync func(context.Context) (Result, error), syncInterval time.Duration) error {
+	// Back off exponentially on failure so a transient error doesn't delay the
+	// first success by a full sync interval.
+	errorBackoff := initialErrorBackoff
+	for {
+		result, err := sync(ctx)
+		if err != nil {
+			klog.ErrorS(err, "failed to provision managed kubeconfig")
+		}
+		var wait time.Duration
+		wait, errorBackoff = nextReconcileWait(result, err, syncInterval, errorBackoff)
+
+		timer := time.NewTimer(wait)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return nil
+		case <-timer.C:
+		}
+	}
+}
+
+func nextReconcileWait(result Result, err error, syncInterval, errorBackoff time.Duration) (time.Duration, time.Duration) {
+	if err == nil {
+		wait := syncInterval
+		if result.RequeueAfter > 0 {
+			wait = min(wait, result.RequeueAfter)
+		}
+		return wait, initialErrorBackoff
+	}
+
+	var retryAfter *retryAfterError
+	if errors.As(err, &retryAfter) {
+		return retryAfter.after, initialErrorBackoff
+	}
+	return min(errorBackoff, syncInterval), min(errorBackoff*2, maxErrorBackoff)
+}
+
+func (p *Provisioner) Sync(ctx context.Context) (Result, error) {
+	sourceConfig, cluster, sourceHash, err := p.loadSourceKubeconfig(ctx)
+	if err != nil {
+		return Result{}, err
+	}
+
+	hostingServiceAccount, err := p.HostingClient.CoreV1().ServiceAccounts(p.TargetNamespace).Get(
+		ctx,
+		p.HostingServiceAccountName,
+		metav1.GetOptions{},
+	)
+	if err != nil {
+		return Result{}, errors.Wrapf(err, "failed to get hosting serviceaccount %s/%s",
+			p.TargetNamespace, p.HostingServiceAccountName)
+	}
+
+	existing, err := p.HostingClient.CoreV1().Secrets(p.TargetNamespace).Get(ctx, p.TargetSecret, metav1.GetOptions{})
+	switch {
+	case apierrors.IsNotFound(err):
+		existing = nil
+	case err != nil:
+		return Result{}, errors.Wrapf(err, "failed to get managed kubeconfig secret %s/%s", p.TargetNamespace, p.TargetSecret)
+	}
+	if existing != nil && !metav1.IsControlledBy(existing, hostingServiceAccount) {
+		err := errors.Errorf("managed kubeconfig secret %s/%s is not controlled by serviceaccount %s/%s",
+			p.TargetNamespace, p.TargetSecret, hostingServiceAccount.Namespace, hostingServiceAccount.Name)
+		p.EventRecorder.Eventf(
+			existing,
+			hostingServiceAccount,
+			corev1.EventTypeWarning,
+			managedKubeconfigSecretOwnershipConflictReason,
+			provisioningBlockedAction,
+			"%v",
+			err,
+		)
+		return Result{}, err
+	}
+
+	managedClient, err := p.ManagedClientFactory(sourceConfig)
+	if err != nil {
+		return Result{}, err
+	}
+
+	managedServiceAccount, err := managedClient.CoreV1().ServiceAccounts(p.ManagedServiceAccountNamespace).Get(
+		ctx,
+		p.ManagedServiceAccountName,
+		metav1.GetOptions{},
+	)
+	if err != nil {
+		return Result{}, errors.Wrapf(err, "failed to get managed serviceaccount %s/%s",
+			p.ManagedServiceAccountNamespace, p.ManagedServiceAccountName)
+	}
+	managedServiceAccountUID := string(managedServiceAccount.UID)
+	if fresh, expiration := p.targetSecretFresh(existing, sourceHash, managedServiceAccountUID); fresh {
+		return p.resultForExpiration(expiration), nil
+	}
+
+	tokenRequest, err := p.requestToken(ctx, managedClient)
+	if err != nil {
+		return Result{}, err
+	}
+	expirationTime := tokenRequest.Status.ExpirationTimestamp.UTC()
+
+	kubeconfig, err := buildManagedKubeconfig(cluster, p.ManagedServiceAccountNamespace, p.ManagedServiceAccountName, managedTokenFilePath)
+	if err != nil {
+		return Result{}, err
+	}
+
+	expiration := expirationTime.Format(time.RFC3339)
+	desiredAnnotations := map[string]string{
+		tokenExpirationAnnotation:                expiration,
+		sourceKubeconfigHashAnnotation:           sourceHash,
+		managedServiceAccountNamespaceAnnotation: p.ManagedServiceAccountNamespace,
+		managedServiceAccountNameAnnotation:      p.ManagedServiceAccountName,
+		ManagedServiceAccountUIDAnnotation:       managedServiceAccountUID,
+		tokenExpirationSecondsAnnotation:         strconv.FormatInt(p.TokenExpirationSeconds, 10),
+	}
+	desiredData := map[string][]byte{
+		KubeconfigSecretKey:           kubeconfig,
+		corev1.ServiceAccountTokenKey: []byte(tokenRequest.Status.Token),
+		tokenExpirationKey:            []byte(expiration),
+	}
+
+	secret := p.buildTargetSecret(existing, hostingServiceAccount, desiredAnnotations, desiredData)
+	if existing != nil {
+		if _, err := p.HostingClient.CoreV1().Secrets(p.TargetNamespace).Update(ctx, secret, metav1.UpdateOptions{}); err != nil {
+			return Result{}, errors.Wrapf(err, "failed to update managed kubeconfig secret %s/%s", p.TargetNamespace, p.TargetSecret)
+		}
+	} else {
+		if _, err := p.HostingClient.CoreV1().Secrets(p.TargetNamespace).Create(ctx, secret, metav1.CreateOptions{}); err != nil {
+			return Result{}, errors.Wrapf(err, "failed to create managed kubeconfig secret %s/%s", p.TargetNamespace, p.TargetSecret)
+		}
+	}
+	return p.resultForExpiration(expirationTime), nil
+}
+
+// loadSourceKubeconfig reads the external managed kubeconfig secret, repairs
+// file references from bundled credentials, and rejects non-portable file
+// references, returning the parsed config, its current cluster, and the
+// canonical cluster hash.
+func (p *Provisioner) loadSourceKubeconfig(ctx context.Context) (*clientcmdapi.Config, *clientcmdapi.Cluster, string, error) {
+	source, err := p.HostingClient.CoreV1().Secrets(p.SourceNamespace).Get(ctx, p.SourceSecret, metav1.GetOptions{})
+	if err != nil {
+		return nil, nil, "", errors.Wrapf(err, "failed to get external managed kubeconfig secret %s/%s", p.SourceNamespace, p.SourceSecret)
+	}
+
+	sourceKubeconfig := source.Data[KubeconfigSecretKey]
+	if len(sourceKubeconfig) == 0 {
+		return nil, nil, "", errors.Errorf("external managed kubeconfig secret %s/%s missing %q data", p.SourceNamespace, p.SourceSecret, KubeconfigSecretKey)
+	}
+
+	sourceConfig, err := clientcmd.Load(sourceKubeconfig)
+	if err != nil {
+		return nil, nil, "", errors.Wrapf(err, "failed to load external managed kubeconfig from secret %s/%s", p.SourceNamespace, p.SourceSecret)
+	}
+
+	cluster, authInfo, err := currentClusterAndAuthInfo(sourceConfig)
+	if err != nil {
+		return nil, nil, "", err
+	}
+	repairAuthInfoFromSecretData(authInfo, source.Data)
+	if err := validateClusterIsPortable(cluster); err != nil {
+		return nil, nil, "", err
+	}
+	if err := validateAuthInfoIsPortable(authInfo); err != nil {
+		return nil, nil, "", err
+	}
+
+	sourceHash, err := sourceKubeconfigHashFromCluster(cluster)
+	if err != nil {
+		return nil, nil, "", err
+	}
+	return sourceConfig, cluster, sourceHash, nil
+}
+
+// requestToken mints a managed serviceaccount token and verifies its actual
+// lifetime leaves room for the configured refresh-before window.
+func (p *Provisioner) requestToken(ctx context.Context, managedClient kubernetes.Interface) (*authenticationv1.TokenRequest, error) {
+	tokenRequest, err := managedClient.CoreV1().ServiceAccounts(p.ManagedServiceAccountNamespace).CreateToken(
+		ctx,
+		p.ManagedServiceAccountName,
+		&authenticationv1.TokenRequest{
+			Spec: authenticationv1.TokenRequestSpec{
+				ExpirationSeconds: &p.TokenExpirationSeconds,
+			},
+		},
+		metav1.CreateOptions{},
+	)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to request token for managed serviceaccount %s/%s",
+			p.ManagedServiceAccountNamespace, p.ManagedServiceAccountName)
+	}
+	if len(tokenRequest.Status.Token) == 0 {
+		return nil, errors.Errorf("token request for managed serviceaccount %s/%s returned an empty token",
+			p.ManagedServiceAccountNamespace, p.ManagedServiceAccountName)
+	}
+	expirationTime := tokenRequest.Status.ExpirationTimestamp.UTC()
+	now := p.Clock.Now().UTC()
+	refreshAt := expirationTime.Add(-p.RefreshBefore)
+	if !refreshAt.After(now) {
+		err := errors.Errorf(
+			"token request for managed serviceaccount %s/%s expires at %s, which does not allow the configured refresh-before duration %s",
+			p.ManagedServiceAccountNamespace, p.ManagedServiceAccountName, expirationTime.Format(time.RFC3339), p.RefreshBefore)
+		return nil, &retryAfterError{
+			err:   err,
+			after: retryAfterShortToken(expirationTime, now, p.SyncInterval),
+		}
+	}
+	return tokenRequest, nil
+}
+
+func retryAfterShortToken(expiration, now time.Time, syncInterval time.Duration) time.Duration {
+	remaining := expiration.Sub(now)
+	if remaining <= 0 {
+		return syncInterval
+	}
+	grace := min(syncInterval, remaining/2)
+	return remaining - grace
+}
+
+func (p *Provisioner) buildTargetSecret(
+	existing *corev1.Secret,
+	hostingServiceAccount *corev1.ServiceAccount,
+	annotations map[string]string,
+	data map[string][]byte,
+) *corev1.Secret {
+	var secret *corev1.Secret
+	if existing != nil {
+		secret = existing.DeepCopy()
+	} else {
+		secret = &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            p.TargetSecret,
+				Namespace:       p.TargetNamespace,
+				OwnerReferences: []metav1.OwnerReference{serviceAccountOwnerReference(hostingServiceAccount)},
+			},
+		}
+	}
+
+	secret.Type = corev1.SecretTypeOpaque
+	if secret.Annotations == nil {
+		secret.Annotations = map[string]string{}
+	}
+	for k, v := range annotations {
+		secret.Annotations[k] = v
+	}
+	secret.Data = data
+	return secret
+}
+
+// Complete fills in defaults and validates the configuration. It must be called
+// before Sync.
+func (p *Provisioner) Complete() error {
+	if p.HostingClient == nil {
+		return errors.New("hosting client is required")
+	}
+	if p.EventRecorder == nil {
+		return errors.New("event recorder is required")
+	}
+	if len(p.SourceNamespace) == 0 {
+		return errors.New("source namespace is required")
+	}
+	if len(p.SourceSecret) == 0 {
+		p.SourceSecret = DefaultExternalManagedKubeConfigSecret
+	}
+	if len(p.TargetNamespace) == 0 {
+		return errors.New("target namespace is required")
+	}
+	if len(p.TargetSecret) == 0 {
+		return errors.New("managed kubeconfig secret is required")
+	}
+	if p.SourceNamespace == p.TargetNamespace && p.SourceSecret == p.TargetSecret {
+		return errors.Errorf("managed kubeconfig secret %s/%s must differ from the external managed kubeconfig secret %s/%s",
+			p.TargetNamespace, p.TargetSecret, p.SourceNamespace, p.SourceSecret)
+	}
+	if len(p.ManagedServiceAccountNamespace) == 0 {
+		p.ManagedServiceAccountNamespace = p.TargetNamespace
+	}
+	if len(p.ManagedServiceAccountName) == 0 {
+		p.ManagedServiceAccountName = DefaultManagedServiceAccountName
+	}
+	if len(p.HostingServiceAccountName) == 0 {
+		p.HostingServiceAccountName = DefaultHostingServiceAccountName
+	}
+	if p.TokenExpirationSeconds == 0 {
+		p.TokenExpirationSeconds = DefaultTokenExpirationSeconds
+	}
+	if p.RefreshBefore == 0 {
+		p.RefreshBefore = DefaultRefreshBefore
+	}
+	if p.SyncInterval == 0 {
+		p.SyncInterval = DefaultSyncInterval
+	}
+	if err := ValidateRotationSettings(p.TokenExpirationSeconds, p.RefreshBefore, p.SyncInterval); err != nil {
+		return err
+	}
+	if p.ManagedClientFactory == nil {
+		p.ManagedClientFactory = newManagedClient
+	}
+	if p.Clock == nil {
+		p.Clock = clock.RealClock{}
+	}
+	return nil
+}
+
+// targetSecretFresh reports whether the target secret can be reused as is, and
+// returns the token expiration it was validated against.
+func (p *Provisioner) targetSecretFresh(secret *corev1.Secret, sourceHash, managedServiceAccountUID string) (bool, time.Time) {
+	if secret == nil || secret.Annotations == nil {
+		return false, time.Time{}
+	}
+	if secret.Annotations[sourceKubeconfigHashAnnotation] != sourceHash ||
+		secret.Annotations[managedServiceAccountNamespaceAnnotation] != p.ManagedServiceAccountNamespace ||
+		secret.Annotations[managedServiceAccountNameAnnotation] != p.ManagedServiceAccountName ||
+		secret.Annotations[ManagedServiceAccountUIDAnnotation] != managedServiceAccountUID ||
+		secret.Annotations[tokenExpirationSecondsAnnotation] != strconv.FormatInt(p.TokenExpirationSeconds, 10) {
+		return false, time.Time{}
+	}
+	if len(secret.Data[KubeconfigSecretKey]) == 0 ||
+		len(secret.Data[corev1.ServiceAccountTokenKey]) == 0 ||
+		len(secret.Data[tokenExpirationKey]) == 0 {
+		return false, time.Time{}
+	}
+	expiration, err := time.Parse(time.RFC3339, secret.Annotations[tokenExpirationAnnotation])
+	if err != nil {
+		return false, time.Time{}
+	}
+	if string(secret.Data[tokenExpirationKey]) != expiration.Format(time.RFC3339) {
+		return false, time.Time{}
+	}
+	return expiration.After(p.Clock.Now().UTC().Add(p.RefreshBefore)), expiration
+}
+
+func (p *Provisioner) resultForExpiration(expiration time.Time) Result {
+	return Result{RequeueAfter: expiration.Add(-p.RefreshBefore).Sub(p.Clock.Now().UTC())}
+}
+
+func serviceAccountOwnerReference(serviceAccount *corev1.ServiceAccount) metav1.OwnerReference {
+	return metav1.OwnerReference{
+		APIVersion: corev1.SchemeGroupVersion.String(),
+		Kind:       "ServiceAccount",
+		Name:       serviceAccount.Name,
+		UID:        serviceAccount.UID,
+		Controller: ptr.To(true),
+	}
+}
+
+func buildManagedKubeconfig(cluster *clientcmdapi.Cluster, namespace, serviceAccountName, tokenFile string) ([]byte, error) {
+	config := clientcmdapi.Config{
+		Clusters: map[string]*clientcmdapi.Cluster{
+			"managed": cluster.DeepCopy(),
+		},
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			serviceAccountName: {
+				TokenFile: tokenFile,
+			},
+		},
+		Contexts: map[string]*clientcmdapi.Context{
+			"managed": {
+				Cluster:   "managed",
+				AuthInfo:  serviceAccountName,
+				Namespace: namespace,
+			},
+		},
+		CurrentContext: "managed",
+	}
+
+	kubeconfig, err := clientcmd.Write(config)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to write managed serviceaccount kubeconfig")
+	}
+	return kubeconfig, nil
+}
+
+func currentClusterAndAuthInfo(config *clientcmdapi.Config) (*clientcmdapi.Cluster, *clientcmdapi.AuthInfo, error) {
+	if config == nil {
+		return nil, nil, errors.New("external managed kubeconfig is empty")
+	}
+	contextName := config.CurrentContext
+	if len(contextName) == 0 && len(config.Contexts) == 1 {
+		for name := range config.Contexts {
+			contextName = name
+		}
+		config.CurrentContext = contextName
+	}
+	context := config.Contexts[contextName]
+	if context == nil {
+		return nil, nil, errors.Errorf("external managed kubeconfig current context %q not found", contextName)
+	}
+	cluster := config.Clusters[context.Cluster]
+	if cluster == nil {
+		return nil, nil, errors.Errorf("external managed kubeconfig cluster %q not found", context.Cluster)
+	}
+	authInfo := config.AuthInfos[context.AuthInfo]
+	if authInfo == nil {
+		return nil, nil, errors.Errorf("external managed kubeconfig user %q not found", context.AuthInfo)
+	}
+	return cluster, authInfo, nil
+}
+
+// repairAuthInfoFromSecretData embeds client credentials the way the OCM
+// operator loads the klusterlet external-managed-kubeconfig secret: when the
+// secret bundles tls.crt/tls.key next to the kubeconfig, use them instead of
+// the file references so a klusterlet-compatible secret also works here.
+func repairAuthInfoFromSecretData(authInfo *clientcmdapi.AuthInfo, data map[string][]byte) {
+	if certData, ok := data[corev1.TLSCertKey]; ok && len(authInfo.ClientCertificateData) == 0 {
+		authInfo.ClientCertificateData = certData
+		authInfo.ClientCertificate = ""
+	}
+	if keyData, ok := data[corev1.TLSPrivateKeyKey]; ok && len(authInfo.ClientKeyData) == 0 {
+		authInfo.ClientKeyData = keyData
+		authInfo.ClientKey = ""
+	}
+}
+
+func validateClusterIsPortable(cluster *clientcmdapi.Cluster) error {
+	if len(cluster.CertificateAuthority) > 0 {
+		return errors.Errorf("external managed kubeconfig cluster references certificate-authority file %q, which is not portable",
+			cluster.CertificateAuthority)
+	}
+	return nil
+}
+
+func validateAuthInfoIsPortable(authInfo *clientcmdapi.AuthInfo) error {
+	if authInfo.Exec != nil {
+		return errors.Errorf("external managed kubeconfig user references exec credential plugin %q, which is not portable",
+			authInfo.Exec.Command)
+	}
+	if authInfo.AuthProvider != nil {
+		return errors.Errorf("external managed kubeconfig user references auth provider %q, which is not portable",
+			authInfo.AuthProvider.Name)
+	}
+	for _, ref := range []struct{ path, description string }{
+		{authInfo.ClientCertificate, "client-certificate file"},
+		{authInfo.ClientKey, "client-key file"},
+		{authInfo.TokenFile, "tokenFile"},
+	} {
+		if len(ref.path) > 0 {
+			return errors.Errorf("external managed kubeconfig user references %s %q, which is not portable",
+				ref.description, ref.path)
+		}
+	}
+	return nil
+}
+
+// sourceKubeconfigHashFromCluster hashes the canonical cluster form so formatting-only changes don't churn the token.
+func sourceKubeconfigHashFromCluster(cluster *clientcmdapi.Cluster) (string, error) {
+	sanitized := clientcmdapi.Config{
+		Clusters: map[string]*clientcmdapi.Cluster{
+			"managed": cluster.DeepCopy(),
+		},
+		Contexts: map[string]*clientcmdapi.Context{
+			"managed": {
+				Cluster: "managed",
+			},
+		},
+		CurrentContext: "managed",
+	}
+	data, err := clientcmd.Write(sanitized)
+	if err != nil {
+		return "", errors.Wrapf(err, "failed to write external managed kubeconfig hash input")
+	}
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:]), nil
+}

--- a/pkg/addon/provisioner/provisioner_test.go
+++ b/pkg/addon/provisioner/provisioner_test.go
@@ -1,0 +1,980 @@
+package provisioner
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	authenticationv1 "k8s.io/api/authentication/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+	fakekube "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/rest"
+	clienttesting "k8s.io/client-go/testing"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	kevents "k8s.io/client-go/tools/events"
+	clock "k8s.io/utils/clock/testing"
+)
+
+func TestNewManagedClientRequestTimeout(t *testing.T) {
+	config := &clientcmdapi.Config{
+		Clusters: map[string]*clientcmdapi.Cluster{
+			"managed": {Server: "https://managed.example.com"},
+		},
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			"user": {Token: "token"},
+		},
+		Contexts: map[string]*clientcmdapi.Context{
+			"managed": {Cluster: "managed", AuthInfo: "user"},
+		},
+		CurrentContext: "managed",
+	}
+
+	client, err := newManagedClient(config)
+	assert.NoError(t, err)
+	restClient, ok := client.Discovery().RESTClient().(*rest.RESTClient)
+	if assert.True(t, ok, "expected concrete REST client") {
+		assert.Equal(t, DefaultRequestTimeout, restClient.Client.Timeout)
+	}
+}
+
+func TestCurrentClusterAndAuthInfoDefaultsSingleContext(t *testing.T) {
+	config := &clientcmdapi.Config{
+		Clusters: map[string]*clientcmdapi.Cluster{
+			"managed": {Server: "https://managed.example.com"},
+		},
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			"user": {Token: "token"},
+		},
+		Contexts: map[string]*clientcmdapi.Context{
+			"only-context": {Cluster: "managed", AuthInfo: "user"},
+		},
+	}
+
+	cluster, authInfo, err := currentClusterAndAuthInfo(config)
+	assert.NoError(t, err)
+	assert.Same(t, config.Clusters["managed"], cluster)
+	assert.Same(t, config.AuthInfos["user"], authInfo)
+	assert.Equal(t, "only-context", config.CurrentContext)
+	_, err = newManagedClient(config)
+	assert.NoError(t, err)
+}
+
+func TestRepairAuthInfoFromSecretData(t *testing.T) {
+	data := map[string][]byte{
+		corev1.TLSCertKey:       []byte("bundled-cert"),
+		corev1.TLSPrivateKeyKey: []byte("bundled-key"),
+	}
+	cases := []struct {
+		name     string
+		authInfo clientcmdapi.AuthInfo
+		expected clientcmdapi.AuthInfo
+	}{
+		{
+			name:     "embeds bundled credentials over file references",
+			authInfo: clientcmdapi.AuthInfo{ClientCertificate: "tls.crt", ClientKey: "tls.key"},
+			expected: clientcmdapi.AuthInfo{ClientCertificateData: []byte("bundled-cert"), ClientKeyData: []byte("bundled-key")},
+		},
+		{
+			name:     "preserves inline credentials",
+			authInfo: clientcmdapi.AuthInfo{ClientCertificateData: []byte("inline-cert"), ClientKeyData: []byte("inline-key")},
+			expected: clientcmdapi.AuthInfo{ClientCertificateData: []byte("inline-cert"), ClientKeyData: []byte("inline-key")},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			repairAuthInfoFromSecretData(&c.authInfo, data)
+			assert.Equal(t, c.expected, c.authInfo)
+		})
+	}
+}
+
+func TestSync(t *testing.T) {
+	now := time.Date(2026, 5, 13, 0, 0, 0, 0, time.UTC)
+	portable := testKubeconfig(t, "https://managed.example.com", []byte("ca-1"))
+	updatedSource := testKubeconfig(t, "https://managed-new.example.com", []byte("ca-2"))
+	caFileSource := testKubeconfigWithCAFile(t, "https://managed.example.com", "/etc/ssl/source-ca.crt")
+
+	cases := []struct {
+		name             string
+		sourceKubeconfig []byte
+		sourceExtraData  map[string][]byte
+		existing         *corev1.Secret
+		mutate           func(*Provisioner)
+		stubToken        func(t *testing.T, client *fakekube.Clientset)
+		expectedError    string
+		expectedRetry    time.Duration
+		validate         func(t *testing.T, hostingClient, managedClient *fakekube.Clientset)
+		validateEvent    func(t *testing.T, recorder *recordingEventRecorder)
+	}{
+		{
+			name:          "external managed kubeconfig secret missing",
+			expectedError: "failed to get external managed kubeconfig secret source-ns/external-managed-kubeconfig: secrets \"external-managed-kubeconfig\" not found",
+		},
+		{
+			name:             "creates managed kubeconfig secret from service account token",
+			sourceKubeconfig: portable,
+			stubToken: func(t *testing.T, client *fakekube.Clientset) {
+				stubTokenRequest(t, client, "token-1", now.Add(time.Hour))
+			},
+			validate: func(t *testing.T, hostingClient, _ *fakekube.Clientset) {
+				secret := getTargetSecret(t, hostingClient)
+				assert.Equal(t, corev1.SecretTypeOpaque, secret.Type)
+				assert.Equal(t, now.Add(time.Hour).Format(time.RFC3339), secret.Annotations[tokenExpirationAnnotation])
+				assert.Equal(t, sourceKubeconfigHash(portable), secret.Annotations[sourceKubeconfigHashAnnotation])
+				assert.Equal(t, "addon-ns", secret.Annotations[managedServiceAccountNamespaceAnnotation])
+				assert.Equal(t, "managed-serviceaccount", secret.Annotations[managedServiceAccountNameAnnotation])
+				assert.Equal(t, "managed-serviceaccount-uid", secret.Annotations[ManagedServiceAccountUIDAnnotation])
+				assert.Equal(t, "3600", secret.Annotations[tokenExpirationSecondsAnnotation])
+
+				kubeconfig := loadTargetKubeconfig(t, secret)
+				assert.Equal(t, "https://managed.example.com", kubeconfig.Clusters["managed"].Server)
+				assert.Equal(t, []byte("ca-1"), kubeconfig.Clusters["managed"].CertificateAuthorityData)
+				assert.Empty(t, kubeconfig.AuthInfos["managed-serviceaccount"].Token)
+				assert.Equal(t, managedTokenFilePath, kubeconfig.AuthInfos["managed-serviceaccount"].TokenFile)
+				assert.Equal(t, []byte("token-1"), secret.Data[corev1.ServiceAccountTokenKey])
+				assert.Equal(t, "managed", kubeconfig.CurrentContext)
+				assertControlledByHostingServiceAccount(t, secret)
+			},
+		},
+		{
+			name:             "skips refresh when token is still valid and source cluster info unchanged",
+			sourceKubeconfig: portable,
+			existing:         freshTargetSecret(now.Add(2*time.Hour), portable),
+			validate: func(t *testing.T, hostingClient, managedClient *fakekube.Clientset) {
+				assertNoAction(t, hostingClient.Actions(), "update", "secrets")
+				assertNoAction(t, managedClient.Actions(), "create", "serviceaccounts/token")
+			},
+		},
+		{
+			name:             "refreshes when managed serviceaccount identity changes",
+			sourceKubeconfig: portable,
+			existing:         freshTargetSecret(now.Add(2*time.Hour), portable),
+			mutate: func(o *Provisioner) {
+				o.ManagedServiceAccountNamespace = "other-ns"
+				o.ManagedServiceAccountName = "renamed-sa"
+			},
+			stubToken: func(t *testing.T, client *fakekube.Clientset) {
+				stubTokenRequestFor(t, client, "other-ns", "renamed-sa", 3600, "token-rename", now.Add(time.Hour))
+			},
+			validate: func(t *testing.T, hostingClient, _ *fakekube.Clientset) {
+				secret := getTargetSecret(t, hostingClient)
+				assert.Equal(t, "other-ns", secret.Annotations[managedServiceAccountNamespaceAnnotation])
+				assert.Equal(t, "renamed-sa", secret.Annotations[managedServiceAccountNameAnnotation])
+
+				kubeconfig := loadTargetKubeconfig(t, secret)
+				assert.Equal(t, managedTokenFilePath, kubeconfig.AuthInfos["renamed-sa"].TokenFile)
+				assert.Equal(t, []byte("token-rename"), secret.Data[corev1.ServiceAccountTokenKey])
+				assert.Equal(t, "other-ns", kubeconfig.Contexts["managed"].Namespace)
+			},
+		},
+		{
+			name:             "refreshes when managed serviceaccount is recreated",
+			sourceKubeconfig: portable,
+			existing: freshTargetSecret(now.Add(2*time.Hour), portable, func(secret *corev1.Secret) {
+				secret.Annotations[ManagedServiceAccountUIDAnnotation] = "old-managed-serviceaccount-uid"
+			}),
+			stubToken: func(t *testing.T, client *fakekube.Clientset) {
+				stubTokenRequest(t, client, "token-recreated", now.Add(time.Hour))
+			},
+			validate: func(t *testing.T, hostingClient, _ *fakekube.Clientset) {
+				secret := getTargetSecret(t, hostingClient)
+				assert.Equal(t, "managed-serviceaccount-uid", secret.Annotations[ManagedServiceAccountUIDAnnotation])
+
+				kubeconfig := loadTargetKubeconfig(t, secret)
+				assert.Equal(t, managedTokenFilePath, kubeconfig.AuthInfos["managed-serviceaccount"].TokenFile)
+				assert.Equal(t, []byte("token-recreated"), secret.Data[corev1.ServiceAccountTokenKey])
+			},
+		},
+		{
+			name:             "refreshes when token expiration seconds changes",
+			sourceKubeconfig: portable,
+			existing:         freshTargetSecret(now.Add(2*time.Hour), portable),
+			mutate: func(o *Provisioner) {
+				o.TokenExpirationSeconds = 14400
+			},
+			stubToken: func(t *testing.T, client *fakekube.Clientset) {
+				stubTokenRequestFor(t, client, "addon-ns", "managed-serviceaccount", 14400, "token-longer", now.Add(4*time.Hour))
+			},
+			validate: func(t *testing.T, hostingClient, _ *fakekube.Clientset) {
+				secret := getTargetSecret(t, hostingClient)
+				assert.Equal(t, "14400", secret.Annotations[tokenExpirationSecondsAnnotation])
+				assert.Equal(t, now.Add(4*time.Hour).Format(time.RFC3339), secret.Annotations[tokenExpirationAnnotation])
+			},
+		},
+		{
+			name:             "refreshes when token is expiring",
+			sourceKubeconfig: portable,
+			existing: existingTargetSecret(
+				map[string]string{
+					tokenExpirationAnnotation:      now.Add(5 * time.Minute).Format(time.RFC3339),
+					sourceKubeconfigHashAnnotation: sourceKubeconfigHash(portable),
+				},
+				map[string][]byte{
+					KubeconfigSecretKey: []byte("existing"),
+				},
+			),
+			stubToken: func(t *testing.T, client *fakekube.Clientset) {
+				stubTokenRequest(t, client, "token-2", now.Add(time.Hour))
+			},
+			validate: func(t *testing.T, hostingClient, _ *fakekube.Clientset) {
+				secret := getTargetSecret(t, hostingClient)
+				kubeconfig := loadTargetKubeconfig(t, secret)
+				assert.Equal(t, managedTokenFilePath, kubeconfig.AuthInfos["managed-serviceaccount"].TokenFile)
+				assert.Equal(t, []byte("token-2"), secret.Data[corev1.ServiceAccountTokenKey])
+				assert.Equal(t, now.Add(time.Hour).Format(time.RFC3339), secret.Annotations[tokenExpirationAnnotation])
+			},
+		},
+		{
+			name:             "refreshes when source cluster info changes",
+			sourceKubeconfig: updatedSource,
+			existing: existingTargetSecret(
+				map[string]string{
+					tokenExpirationAnnotation:      now.Add(2 * time.Hour).Format(time.RFC3339),
+					sourceKubeconfigHashAnnotation: "old-hash",
+				},
+				map[string][]byte{
+					KubeconfigSecretKey: []byte("existing"),
+				},
+			),
+			stubToken: func(t *testing.T, client *fakekube.Clientset) {
+				stubTokenRequest(t, client, "token-3", now.Add(time.Hour))
+			},
+			validate: func(t *testing.T, hostingClient, _ *fakekube.Clientset) {
+				secret := getTargetSecret(t, hostingClient)
+				kubeconfig := loadTargetKubeconfig(t, secret)
+				assert.Equal(t, "https://managed-new.example.com", kubeconfig.Clusters["managed"].Server)
+				assert.Equal(t, []byte("ca-2"), kubeconfig.Clusters["managed"].CertificateAuthorityData)
+				assert.Equal(t, managedTokenFilePath, kubeconfig.AuthInfos["managed-serviceaccount"].TokenFile)
+				assert.Equal(t, []byte("token-3"), secret.Data[corev1.ServiceAccountTokenKey])
+				assert.Equal(t, sourceKubeconfigHash(updatedSource), secret.Annotations[sourceKubeconfigHashAnnotation])
+			},
+		},
+		{
+			name:             "refreshes when target secret data is missing",
+			sourceKubeconfig: portable,
+			existing: existingTargetSecret(
+				map[string]string{
+					tokenExpirationAnnotation:      now.Add(2 * time.Hour).Format(time.RFC3339),
+					sourceKubeconfigHashAnnotation: sourceKubeconfigHash(portable),
+				},
+				map[string][]byte{},
+			),
+			stubToken: func(t *testing.T, client *fakekube.Clientset) {
+				stubTokenRequest(t, client, "token-repair", now.Add(time.Hour))
+			},
+			validate: func(t *testing.T, hostingClient, _ *fakekube.Clientset) {
+				secret := getTargetSecret(t, hostingClient)
+				assert.NotEmpty(t, secret.Data[KubeconfigSecretKey])
+				assert.Equal(t, now.Add(time.Hour).Format(time.RFC3339), string(secret.Data[tokenExpirationKey]))
+
+				kubeconfig := loadTargetKubeconfig(t, secret)
+				assert.Equal(t, managedTokenFilePath, kubeconfig.AuthInfos["managed-serviceaccount"].TokenFile)
+				assert.Equal(t, []byte("token-repair"), secret.Data[corev1.ServiceAccountTokenKey])
+			},
+		},
+		{
+			name:             "rejects source kubeconfig with file-based certificate authority",
+			sourceKubeconfig: caFileSource,
+			expectedError:    "external managed kubeconfig cluster references certificate-authority file \"/etc/ssl/source-ca.crt\", which is not portable",
+		},
+		{
+			name:             "rejects source kubeconfig with file-based certificate authority even when target secret is fresh",
+			sourceKubeconfig: caFileSource,
+			existing:         freshTargetSecret(now.Add(2*time.Hour), caFileSource),
+			expectedError:    "external managed kubeconfig cluster references certificate-authority file \"/etc/ssl/source-ca.crt\", which is not portable",
+		},
+		{
+			name: "repairs file-based client credentials from bundled tls.crt and tls.key",
+			sourceKubeconfig: testKubeconfigWithAuthInfo(t, "https://managed.example.com", []byte("ca-1"),
+				clientcmdapi.AuthInfo{ClientCertificate: "tls.crt", ClientKey: "tls.key"}),
+			sourceExtraData: map[string][]byte{
+				corev1.TLSCertKey:       []byte("bundled-cert"),
+				corev1.TLSPrivateKeyKey: []byte("bundled-key"),
+			},
+			stubToken: func(t *testing.T, client *fakekube.Clientset) {
+				stubTokenRequest(t, client, "token-repaired", now.Add(time.Hour))
+			},
+			validate: func(t *testing.T, hostingClient, _ *fakekube.Clientset) {
+				secret := getTargetSecret(t, hostingClient)
+				kubeconfig := loadTargetKubeconfig(t, secret)
+				assert.Equal(t, managedTokenFilePath, kubeconfig.AuthInfos["managed-serviceaccount"].TokenFile)
+				assert.Empty(t, kubeconfig.AuthInfos["managed-serviceaccount"].ClientCertificateData)
+				assert.Equal(t, []byte("token-repaired"), secret.Data[corev1.ServiceAccountTokenKey])
+			},
+		},
+		{
+			name:             "rejects source kubeconfig with client-certificate file",
+			sourceKubeconfig: testKubeconfigWithAuthInfo(t, "https://managed.example.com", []byte("ca-1"), clientcmdapi.AuthInfo{ClientCertificate: "/etc/creds/client.crt", ClientKeyData: []byte("key")}),
+			expectedError:    "external managed kubeconfig user references client-certificate file \"/etc/creds/client.crt\", which is not portable",
+		},
+		{
+			name:             "rejects source kubeconfig with client-key file",
+			sourceKubeconfig: testKubeconfigWithAuthInfo(t, "https://managed.example.com", []byte("ca-1"), clientcmdapi.AuthInfo{ClientCertificateData: []byte("crt"), ClientKey: "/etc/creds/client.key"}),
+			expectedError:    "external managed kubeconfig user references client-key file \"/etc/creds/client.key\", which is not portable",
+		},
+		{
+			name:             "rejects source kubeconfig with token file",
+			sourceKubeconfig: testKubeconfigWithAuthInfo(t, "https://managed.example.com", []byte("ca-1"), clientcmdapi.AuthInfo{TokenFile: "/var/run/secrets/token"}),
+			expectedError:    "external managed kubeconfig user references tokenFile \"/var/run/secrets/token\", which is not portable",
+		},
+		{
+			name: "rejects source kubeconfig with exec credential plugin",
+			sourceKubeconfig: testKubeconfigWithAuthInfo(t, "https://managed.example.com", []byte("ca-1"), clientcmdapi.AuthInfo{
+				Exec: &clientcmdapi.ExecConfig{
+					Command:    "gke-gcloud-auth-plugin",
+					APIVersion: "client.authentication.k8s.io/v1beta1",
+				},
+			}),
+			expectedError: "external managed kubeconfig user references exec credential plugin \"gke-gcloud-auth-plugin\", which is not portable",
+		},
+		{
+			name: "rejects source kubeconfig with auth provider",
+			sourceKubeconfig: testKubeconfigWithAuthInfo(t, "https://managed.example.com", []byte("ca-1"), clientcmdapi.AuthInfo{
+				AuthProvider: &clientcmdapi.AuthProviderConfig{Name: "gcp"},
+			}),
+			expectedError: "external managed kubeconfig user references auth provider \"gcp\", which is not portable",
+		},
+		{
+			name:             "rejects unowned managed kubeconfig secret",
+			sourceKubeconfig: portable,
+			existing: &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
+				Name: "target-kubeconfig", Namespace: "addon-ns",
+			}},
+			expectedError: "managed kubeconfig secret addon-ns/target-kubeconfig is not controlled by serviceaccount addon-ns/managed-serviceaccount-kubeconfig-provisioner",
+			validate: func(t *testing.T, hostingClient, managedClient *fakekube.Clientset) {
+				assertNoAction(t, hostingClient.Actions(), "create", "secrets")
+				assertNoAction(t, hostingClient.Actions(), "update", "secrets")
+				assertNoAction(t, managedClient.Actions(), "create", "serviceaccounts/token")
+			},
+			validateEvent: func(t *testing.T, recorder *recordingEventRecorder) {
+				if assert.Len(t, recorder.events, 1) {
+					event := recorder.events[0]
+					assert.Equal(t, corev1.EventTypeWarning, event.eventType)
+					assert.Equal(t, managedKubeconfigSecretOwnershipConflictReason, event.reason)
+					assert.Equal(t, provisioningBlockedAction, event.action)
+					assert.Equal(t,
+						"managed kubeconfig secret addon-ns/target-kubeconfig is not controlled by serviceaccount addon-ns/managed-serviceaccount-kubeconfig-provisioner",
+						event.note,
+					)
+
+					regarding, ok := event.regarding.(*corev1.Secret)
+					if assert.True(t, ok) {
+						assert.Equal(t, "addon-ns", regarding.Namespace)
+						assert.Equal(t, "target-kubeconfig", regarding.Name)
+					}
+					related, ok := event.related.(*corev1.ServiceAccount)
+					if assert.True(t, ok) {
+						assert.Equal(t, "addon-ns", related.Namespace)
+						assert.Equal(t, DefaultHostingServiceAccountName, related.Name)
+					}
+				}
+			},
+		},
+		{
+			name:             "rejects token lifetime shorter than refresh window",
+			sourceKubeconfig: portable,
+			stubToken: func(t *testing.T, client *fakekube.Clientset) {
+				stubTokenRequest(t, client, "too-short", now.Add(20*time.Minute))
+			},
+			expectedError: "token request for managed serviceaccount addon-ns/managed-serviceaccount expires at 2026-05-13T00:20:00Z, which does not allow the configured refresh-before duration 30m0s",
+			expectedRetry: 15 * time.Minute,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			objs := []runtime.Object{hostingServiceAccount()}
+			if c.sourceKubeconfig != nil {
+				source := newSourceSecret(c.sourceKubeconfig)
+				for key, value := range c.sourceExtraData {
+					source.Data[key] = value
+				}
+				objs = append(objs, source)
+			}
+			if c.existing != nil {
+				objs = append(objs, c.existing)
+			}
+			hostingClient := fakekube.NewSimpleClientset(objs...)
+			managedClient := fakekube.NewSimpleClientset(
+				managedServiceAccount("addon-ns", "managed-serviceaccount", "managed-serviceaccount-uid"),
+				managedServiceAccount("other-ns", "renamed-sa", "renamed-sa-uid"),
+			)
+			if c.stubToken != nil {
+				c.stubToken(t, managedClient)
+			}
+			p := newTestProvisioner(hostingClient, managedClient, func(o *Provisioner) {
+				o.Clock = clock.NewFakeClock(now)
+				if c.mutate != nil {
+					c.mutate(o)
+				}
+			})
+			recorder := &recordingEventRecorder{}
+			p.EventRecorder = recorder
+
+			_, err := p.Sync(context.Background())
+
+			if len(c.expectedError) > 0 {
+				assert.EqualError(t, err, c.expectedError)
+			} else {
+				assert.NoError(t, err)
+			}
+			if c.expectedRetry > 0 {
+				var retryErr *retryAfterError
+				if assert.ErrorAs(t, err, &retryErr) {
+					assert.Equal(t, c.expectedRetry, retryErr.after)
+				}
+			}
+			if c.validate != nil {
+				c.validate(t, hostingClient, managedClient)
+			}
+			if c.validateEvent != nil {
+				c.validateEvent(t, recorder)
+			}
+		})
+	}
+}
+
+func TestSyncSchedulesRefreshFromActualExpiration(t *testing.T) {
+	now := time.Date(2026, 5, 13, 0, 0, 0, 0, time.UTC)
+	portable := testKubeconfig(t, "https://managed.example.com", []byte("ca-1"))
+	hostingClient := fakekube.NewSimpleClientset(
+		hostingServiceAccount(),
+		newSourceSecret(portable),
+	)
+	managedClient := fakekube.NewSimpleClientset(
+		managedServiceAccount("addon-ns", "managed-serviceaccount", "managed-serviceaccount-uid"),
+	)
+	stubTokenRequest(t, managedClient, "token", now.Add(45*time.Minute))
+	p := newTestProvisioner(hostingClient, managedClient, func(p *Provisioner) {
+		p.Clock = clock.NewFakeClock(now)
+		p.RefreshBefore = 10 * time.Minute
+	})
+
+	result, err := p.Sync(context.Background())
+
+	assert.NoError(t, err)
+	assert.Equal(t, 35*time.Minute, result.RequeueAfter)
+}
+
+func TestRunReconcile(t *testing.T) {
+	cases := []struct {
+		name              string
+		cancelBeforeStart bool
+		onSync            func(count int64, cancel context.CancelFunc) (Result, error)
+		syncInterval      time.Duration
+		minSyncCalls      int64
+		maxElapsed        time.Duration
+	}{
+		{
+			name: "syncs until the context is cancelled",
+			onSync: func(count int64, cancel context.CancelFunc) (Result, error) {
+				if count >= 3 {
+					cancel()
+				}
+				return Result{}, nil
+			},
+			syncInterval: time.Millisecond,
+			minSyncCalls: 3,
+		},
+		{
+			name: "continues after a sync error",
+			onSync: func(count int64, cancel context.CancelFunc) (Result, error) {
+				if count >= 2 {
+					cancel()
+					return Result{}, nil
+				}
+				return Result{}, fmt.Errorf("transient sync error %d", count)
+			},
+			syncInterval: time.Millisecond,
+			minSyncCalls: 2,
+		},
+		{
+			// a transient failure must retry on the error backoff, not the full sync interval
+			name: "retries quickly after a transient error",
+			onSync: func(count int64, cancel context.CancelFunc) (Result, error) {
+				if count == 1 {
+					return Result{}, errors.New("transient")
+				}
+				cancel()
+				return Result{}, nil
+			},
+			syncInterval: time.Hour,
+			minSyncCalls: 2,
+		},
+		{
+			name: "uses the token refresh deadline before the sync interval",
+			onSync: func(count int64, cancel context.CancelFunc) (Result, error) {
+				if count >= 2 {
+					cancel()
+				}
+				return Result{RequeueAfter: time.Millisecond}, nil
+			},
+			syncInterval: time.Hour,
+			minSyncCalls: 2,
+			maxElapsed:   5 * time.Second,
+		},
+		{
+			name:              "returns promptly when the context is already cancelled",
+			cancelBeforeStart: true,
+			syncInterval:      time.Hour,
+			maxElapsed:        5 * time.Second,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			if c.cancelBeforeStart {
+				cancel()
+			}
+			stub := &stubSyncer{}
+			if c.onSync != nil {
+				stub.onSync = func(count int64) (Result, error) {
+					return c.onSync(count, cancel)
+				}
+			}
+
+			start := time.Now()
+			done := make(chan error, 1)
+			go func() {
+				done <- runReconcile(ctx, stub.Sync, c.syncInterval)
+			}()
+
+			select {
+			case err := <-done:
+				assert.NoError(t, err)
+			case <-time.After(30 * time.Second):
+				t.Fatal("runReconcile did not return after context cancellation")
+			}
+
+			syncCalls := atomic.LoadInt64(&stub.syncCalls)
+			assert.GreaterOrEqual(t, syncCalls, c.minSyncCalls)
+			if c.maxElapsed > 0 {
+				assert.Less(t, time.Since(start), c.maxElapsed)
+			}
+		})
+	}
+}
+
+func TestNextReconcileWait(t *testing.T) {
+	err := &retryAfterError{err: errors.New("short token"), after: 15 * time.Minute}
+	wait, errorBackoff := nextReconcileWait(Result{}, err, 5*time.Minute, maxErrorBackoff)
+
+	assert.Equal(t, 15*time.Minute, wait)
+	assert.Equal(t, initialErrorBackoff, errorBackoff)
+}
+
+func TestRetryAfterShortToken(t *testing.T) {
+	now := time.Date(2026, 5, 13, 0, 0, 0, 0, time.UTC)
+	assert.Equal(t, 15*time.Minute, retryAfterShortToken(now.Add(20*time.Minute), now, 5*time.Minute))
+	assert.Equal(t, 3*time.Minute, retryAfterShortToken(now.Add(6*time.Minute), now, 5*time.Minute))
+	assert.Equal(t, 5*time.Minute, retryAfterShortToken(now.Add(-time.Minute), now, 5*time.Minute))
+}
+
+type recordedEvent struct {
+	regarding runtime.Object
+	related   runtime.Object
+	eventType string
+	reason    string
+	action    string
+	note      string
+}
+
+type recordingEventRecorder struct {
+	events []recordedEvent
+}
+
+func (r *recordingEventRecorder) Eventf(
+	regarding runtime.Object,
+	related runtime.Object,
+	eventType, reason, action, note string,
+	args ...interface{},
+) {
+	r.events = append(r.events, recordedEvent{
+		regarding: regarding,
+		related:   related,
+		eventType: eventType,
+		reason:    reason,
+		action:    action,
+		note:      fmt.Sprintf(note, args...),
+	})
+}
+
+type stubSyncer struct {
+	syncCalls int64
+	onSync    func(count int64) (Result, error)
+}
+
+func (s *stubSyncer) Sync(ctx context.Context) (Result, error) {
+	count := atomic.AddInt64(&s.syncCalls, 1)
+	if s.onSync == nil {
+		return Result{}, nil
+	}
+	return s.onSync(count)
+}
+
+func TestCompleteRejectsInvalidConfig(t *testing.T) {
+	cases := []struct {
+		name   string
+		mutate func(*Provisioner)
+	}{
+		{
+			name:   "missing hosting client",
+			mutate: func(o *Provisioner) { o.HostingClient = nil },
+		},
+		{
+			name:   "missing event recorder",
+			mutate: func(o *Provisioner) { o.EventRecorder = nil },
+		},
+		{
+			name:   "empty source namespace",
+			mutate: func(o *Provisioner) { o.SourceNamespace = "" },
+		},
+		{
+			name:   "empty target namespace",
+			mutate: func(o *Provisioner) { o.TargetNamespace = "" },
+		},
+		{
+			name:   "empty target secret",
+			mutate: func(o *Provisioner) { o.TargetSecret = "" },
+		},
+		{
+			name:   "invalid rotation settings",
+			mutate: func(o *Provisioner) { o.TokenExpirationSeconds = minTokenExpirationSeconds - 1 },
+		},
+		{
+			name:   "target secret colliding with source",
+			mutate: func(o *Provisioner) { o.TargetNamespace = "source-ns"; o.TargetSecret = "external-managed-kubeconfig" },
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			p := newTestProvisioner(fakekube.NewSimpleClientset(), fakekube.NewSimpleClientset(), c.mutate)
+			assert.Error(t, p.Complete())
+		})
+	}
+}
+
+func TestValidateRotationSettings(t *testing.T) {
+	cases := []struct {
+		name                   string
+		tokenExpirationSeconds int64
+		refreshBefore          time.Duration
+		syncInterval           time.Duration
+		expectedError          bool
+	}{
+		{
+			name:                   "valid settings",
+			tokenExpirationSeconds: 3600,
+			refreshBefore:          10 * time.Minute,
+			syncInterval:           5 * time.Minute,
+		},
+		{
+			name:                   "minimum token expiration",
+			tokenExpirationSeconds: minTokenExpirationSeconds,
+			refreshBefore:          time.Second,
+			syncInterval:           time.Minute,
+		},
+		{
+			name:                   "maximum token expiration",
+			tokenExpirationSeconds: maxTokenExpirationSeconds,
+			refreshBefore:          time.Minute,
+			syncInterval:           time.Minute,
+		},
+		{
+			name:                   "token expiration below Kubernetes minimum",
+			tokenExpirationSeconds: minTokenExpirationSeconds - 1,
+			refreshBefore:          time.Minute,
+			syncInterval:           time.Minute,
+			expectedError:          true,
+		},
+		{
+			name:                   "token expiration above Kubernetes maximum",
+			tokenExpirationSeconds: maxTokenExpirationSeconds + 1,
+			refreshBefore:          time.Minute,
+			syncInterval:           time.Minute,
+			expectedError:          true,
+		},
+		{
+			name:                   "zero refresh before",
+			tokenExpirationSeconds: 3600,
+			refreshBefore:          0,
+			syncInterval:           time.Minute,
+			expectedError:          true,
+		},
+		{
+			name:                   "negative refresh before",
+			tokenExpirationSeconds: 3600,
+			refreshBefore:          -time.Second,
+			syncInterval:           time.Minute,
+			expectedError:          true,
+		},
+		{
+			name:                   "zero sync interval",
+			tokenExpirationSeconds: 3600,
+			refreshBefore:          time.Minute,
+			syncInterval:           0,
+			expectedError:          true,
+		},
+		{
+			name:                   "negative sync interval",
+			tokenExpirationSeconds: 3600,
+			refreshBefore:          time.Minute,
+			syncInterval:           -time.Second,
+			expectedError:          true,
+		},
+		{
+			name:                   "refresh equals token lifetime",
+			tokenExpirationSeconds: 600,
+			refreshBefore:          10 * time.Minute,
+			syncInterval:           time.Minute,
+			expectedError:          true,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := ValidateRotationSettings(c.tokenExpirationSeconds, c.refreshBefore, c.syncInterval)
+			if c.expectedError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestCompleteAppliesDefaults(t *testing.T) {
+	p := &Provisioner{
+		HostingClient:   fakekube.NewSimpleClientset(),
+		EventRecorder:   kevents.NewFakeRecorder(1),
+		SourceNamespace: "source-ns",
+		TargetNamespace: "addon-ns",
+		TargetSecret:    "target-kubeconfig",
+	}
+
+	assert.NoError(t, p.Complete())
+
+	assert.Equal(t, DefaultExternalManagedKubeConfigSecret, p.SourceSecret)
+	assert.Equal(t, "addon-ns", p.ManagedServiceAccountNamespace)
+	assert.Equal(t, DefaultManagedServiceAccountName, p.ManagedServiceAccountName)
+	assert.Equal(t, DefaultHostingServiceAccountName, p.HostingServiceAccountName)
+	assert.Equal(t, DefaultTokenExpirationSeconds, p.TokenExpirationSeconds)
+	assert.Equal(t, DefaultRefreshBefore, p.RefreshBefore)
+	assert.Equal(t, DefaultSyncInterval, p.SyncInterval)
+}
+
+func newTestProvisioner(hostingClient *fakekube.Clientset, managedClient *fakekube.Clientset, mutate func(*Provisioner)) *Provisioner {
+	p := &Provisioner{
+		HostingClient:                  hostingClient,
+		EventRecorder:                  kevents.NewFakeRecorder(1),
+		SourceNamespace:                "source-ns",
+		SourceSecret:                   "external-managed-kubeconfig",
+		TargetNamespace:                "addon-ns",
+		TargetSecret:                   "target-kubeconfig",
+		ManagedServiceAccountNamespace: "addon-ns",
+		ManagedServiceAccountName:      "managed-serviceaccount",
+		HostingServiceAccountName:      DefaultHostingServiceAccountName,
+		TokenExpirationSeconds:         3600,
+		RefreshBefore:                  30 * time.Minute,
+		SyncInterval:                   DefaultSyncInterval,
+		ManagedClientFactory: func(*clientcmdapi.Config) (kubernetes.Interface, error) {
+			return managedClient, nil
+		},
+	}
+	if mutate != nil {
+		mutate(p)
+	}
+	return p
+}
+
+func newSourceSecret(kubeconfig []byte) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "external-managed-kubeconfig",
+			Namespace: "source-ns",
+		},
+		Data: map[string][]byte{
+			KubeconfigSecretKey: kubeconfig,
+		},
+	}
+}
+
+func managedServiceAccount(namespace, name, uid string) *corev1.ServiceAccount {
+	return &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+			UID:       types.UID(uid),
+		},
+	}
+}
+
+func hostingServiceAccount() *corev1.ServiceAccount {
+	return managedServiceAccount("addon-ns", DefaultHostingServiceAccountName, "hosting-serviceaccount-uid")
+}
+
+// existingTargetSecret builds a pre-existing target secret at addon-ns/target-kubeconfig.
+func existingTargetSecret(annotations map[string]string, data map[string][]byte) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "target-kubeconfig",
+			Namespace:       "addon-ns",
+			Annotations:     annotations,
+			OwnerReferences: []metav1.OwnerReference{serviceAccountOwnerReference(hostingServiceAccount())},
+		},
+		Data: data,
+	}
+}
+
+func assertControlledByHostingServiceAccount(t *testing.T, object metav1.Object) {
+	t.Helper()
+	owner := metav1.GetControllerOf(object)
+	if assert.NotNil(t, owner) {
+		assert.Equal(t, "v1", owner.APIVersion)
+		assert.Equal(t, "ServiceAccount", owner.Kind)
+		assert.Equal(t, DefaultHostingServiceAccountName, owner.Name)
+		assert.Equal(t, types.UID("hosting-serviceaccount-uid"), owner.UID)
+	}
+}
+
+// freshTargetSecret builds a target secret that Sync considers up to date.
+func freshTargetSecret(expires time.Time, sourceKubeconfig []byte, modifiers ...func(*corev1.Secret)) *corev1.Secret {
+	secret := existingTargetSecret(
+		freshTargetAnnotations(expires, sourceKubeconfig),
+		map[string][]byte{
+			KubeconfigSecretKey:           []byte("existing"),
+			corev1.ServiceAccountTokenKey: []byte("existing-token"),
+			tokenExpirationKey:            []byte(expires.Format(time.RFC3339)),
+		},
+	)
+	for _, modify := range modifiers {
+		modify(secret)
+	}
+	return secret
+}
+
+// freshTargetAnnotations returns the annotations the provisioner stamps for the default
+// managed serviceaccount identity, which mark the target secret as up to date.
+func freshTargetAnnotations(expires time.Time, sourceKubeconfig []byte) map[string]string {
+	return map[string]string{
+		tokenExpirationAnnotation:                expires.Format(time.RFC3339),
+		sourceKubeconfigHashAnnotation:           sourceKubeconfigHash(sourceKubeconfig),
+		managedServiceAccountNamespaceAnnotation: "addon-ns",
+		managedServiceAccountNameAnnotation:      "managed-serviceaccount",
+		ManagedServiceAccountUIDAnnotation:       "managed-serviceaccount-uid",
+		tokenExpirationSecondsAnnotation:         "3600",
+	}
+}
+
+func getTargetSecret(t *testing.T, hostingClient *fakekube.Clientset) *corev1.Secret {
+	t.Helper()
+	secret, err := hostingClient.CoreV1().Secrets("addon-ns").Get(context.Background(), "target-kubeconfig", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("failed to get target secret: %v", err)
+	}
+	return secret
+}
+
+func loadTargetKubeconfig(t *testing.T, secret *corev1.Secret) *clientcmdapi.Config {
+	t.Helper()
+	kubeconfig, err := clientcmd.Load(secret.Data[KubeconfigSecretKey])
+	if err != nil {
+		t.Fatalf("failed to load target kubeconfig: %v", err)
+	}
+	return kubeconfig
+}
+
+func testKubeconfig(t *testing.T, server string, ca []byte) []byte {
+	t.Helper()
+	return testKubeconfigWithAuthInfo(t, server, ca, clientcmdapi.AuthInfo{Token: "source-token"})
+}
+
+func testKubeconfigWithCAFile(t *testing.T, server, caFile string) []byte {
+	t.Helper()
+	return writeTestKubeconfig(t, clientcmdapi.Cluster{
+		Server:               server,
+		CertificateAuthority: caFile,
+	}, clientcmdapi.AuthInfo{Token: "source-token"})
+}
+
+func testKubeconfigWithAuthInfo(t *testing.T, server string, ca []byte, authInfo clientcmdapi.AuthInfo) []byte {
+	t.Helper()
+	return writeTestKubeconfig(t, clientcmdapi.Cluster{
+		Server:                   server,
+		CertificateAuthorityData: ca,
+	}, authInfo)
+}
+
+func writeTestKubeconfig(t *testing.T, cluster clientcmdapi.Cluster, authInfo clientcmdapi.AuthInfo) []byte {
+	t.Helper()
+
+	data, err := clientcmd.Write(clientcmdapi.Config{
+		Clusters:       map[string]*clientcmdapi.Cluster{"managed": &cluster},
+		AuthInfos:      map[string]*clientcmdapi.AuthInfo{"source": &authInfo},
+		Contexts:       map[string]*clientcmdapi.Context{"managed": {Cluster: "managed", AuthInfo: "source"}},
+		CurrentContext: "managed",
+	})
+	assert.NoError(t, err)
+	return data
+}
+
+func stubTokenRequest(t *testing.T, client *fakekube.Clientset, token string, expires time.Time) {
+	t.Helper()
+	stubTokenRequestFor(t, client, "addon-ns", "managed-serviceaccount", 3600, token, expires)
+}
+
+func stubTokenRequestFor(t *testing.T, client *fakekube.Clientset, namespace, name string, expirationSeconds int64, token string, expires time.Time) {
+	t.Helper()
+
+	client.PrependReactor("create", "serviceaccounts/token", func(action clienttesting.Action) (bool, runtime.Object, error) {
+		createAction := action.(clienttesting.CreateAction)
+		assert.Equal(t, namespace, action.GetNamespace())
+		assert.Equal(t, name, action.(clienttesting.CreateActionImpl).Name)
+		request := createAction.GetObject().(*authenticationv1.TokenRequest)
+		assert.Equal(t, expirationSeconds, *request.Spec.ExpirationSeconds)
+		return true, &authenticationv1.TokenRequest{
+			Status: authenticationv1.TokenRequestStatus{
+				Token:               token,
+				ExpirationTimestamp: metav1.NewTime(expires),
+			},
+		}, nil
+	})
+}
+
+func assertNoAction(t *testing.T, actions []clienttesting.Action, verb, resource string) {
+	t.Helper()
+
+	for _, action := range actions {
+		if action.Matches(verb, resource) {
+			t.Fatalf("unexpected action %s %s: %#v", verb, resource, action)
+		}
+	}
+}
+
+func sourceKubeconfigHash(kubeconfig []byte) string {
+	config, err := clientcmd.Load(kubeconfig)
+	if err != nil {
+		panic(err)
+	}
+	cluster, _, err := currentClusterAndAuthInfo(config)
+	if err != nil {
+		panic(err)
+	}
+	hash, err := sourceKubeconfigHashFromCluster(cluster)
+	if err != nil {
+		panic(err)
+	}
+	return hash
+}


### PR DESCRIPTION
## Summary

Managed-serviceaccount agents currently run on the managed cluster. This PR adds the addon-framework hosted path, allowing the agent and its kubeconfig provisioner to run on a separate hosting cluster.

The hosted agent needs credentials for both the hub and the managed cluster. The provisioner copies the rotating hub kubeconfig into the addon namespace and creates a short-lived managed-cluster kubeconfig from an external kubeconfig. It refreshes that kubeconfig before the token expires and removes the generated secrets when the addon is deleted.

I kept this scoped to the addon-framework manager (`hubDeployMode=Deployment`). The AddOnTemplate path is unchanged and continues to install the regular agent on the managed cluster.

A three-cluster e2e job exercises the hosted flow. Unit and Helm tests cover manifest placement, RBAC, credential refresh and cleanup, and NetworkPolicy rendering.

## Related issue(s)

None.
