### PR TITLE
:seedling: chore: upgrade to go 1.26

### DIFF
--- a/.github/workflows/go-postsubmit.yml
+++ b/.github/workflows/go-postsubmit.yml
@@ -9,7 +9,7 @@ on:
 
 env:
   # Common versions
-  GO_VERSION: '1.25'
+  GO_VERSION: '1.26'
   GO_REQUIRED_MIN_VERSION: ''
   GOPATH: '/home/runner/work/managed-serviceaccount/managed-serviceaccount/go'
 

--- a/.github/workflows/go-presubmit.yml
+++ b/.github/workflows/go-presubmit.yml
@@ -13,7 +13,7 @@ on:
 
 env:
   # Common versions
-  GO_VERSION: '1.25'
+  GO_VERSION: '1.26'
   GO_REQUIRED_MIN_VERSION: ''
 
 jobs:

--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -6,7 +6,7 @@ on:
       - 'v*.*.*'
 env:
   # Common versions
-  GO_VERSION: '1.25'
+  GO_VERSION: '1.26'
   GO_REQUIRED_MIN_VERSION: ''
   GITHUB_REF: ${{ github.ref }}
   CHART_NAME: managed-serviceaccount

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.25-bookworm AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26-bookworm AS builder
 ARG TARGETOS=linux
 ARG TARGETARCH
 WORKDIR /go/src/github.com/open-cluster-management.io/managed-serviceaccount

--- a/Dockerfile.cp-creds
+++ b/Dockerfile.cp-creds
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.25-bookworm AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26-bookworm AS builder
 ARG TARGETOS=linux
 ARG TARGETARCH
 WORKDIR /go/src/github.com/open-cluster-management.io/managed-serviceaccount

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module open-cluster-management.io/managed-serviceaccount
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/onsi/ginkgo/v2 v2.28.3


### PR DESCRIPTION
Upgrades Go version from 1.25 to 1.26.

Changes:
- `go.mod` — go directive updated to 1.26.0
- `.github/workflows/go-presubmit.yml` — GO_VERSION updated to 1.26
- `.github/workflows/go-postsubmit.yml` — GO_VERSION updated to 1.26
- `.github/workflows/go-release.yml` — GO_VERSION updated to 1.26

Relates to: https://github.com/open-cluster-management-io/ocm/issues/1555

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Go language version requirement updated from 1.25 to 1.26 across build systems, CI/CD pipelines, and module configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->