### PR TITLE
:seedling: Optimize CI by separating image build from e2e

### DIFF
--- a/.github/workflows/go-presubmit.yml
+++ b/.github/workflows/go-presubmit.yml
@@ -39,12 +39,14 @@ jobs:
       - name: images-main
         run: make images
       - name: save image artifact
-        run: docker save quay.io/open-cluster-management/managed-serviceaccount:latest -o /tmp/managed-serviceaccount.tar
+        run: docker save quay.io/open-cluster-management/managed-serviceaccount:latest -o "${{ runner.temp }}/managed-serviceaccount.tar"
       - name: upload image artifact
         uses: actions/upload-artifact@v4
         with:
           name: main-image
-          path: /tmp/managed-serviceaccount.tar
+          path: ${{ runner.temp }}/managed-serviceaccount.tar
+          if-no-files-found: error
+          compression-level: 0
           retention-days: 1
 
   images-cp-creds:
@@ -106,9 +108,9 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: main-image
-          path: /tmp
+          path: ${{ runner.temp }}
       - name: load main image
-        run: docker load -i /tmp/managed-serviceaccount.tar
+        run: docker load -i "${{ runner.temp }}/managed-serviceaccount.tar"
       - name: Install clusteradm
         run: curl -L https://raw.githubusercontent.com/open-cluster-management-io/clusteradm/main/install.sh | bash
       - name: Create k8s Kind Cluster
@@ -149,9 +151,9 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: main-image
-          path: /tmp
+          path: ${{ runner.temp }}
       - name: load main image
-        run: docker load -i /tmp/managed-serviceaccount.tar
+        run: docker load -i "${{ runner.temp }}/managed-serviceaccount.tar"
       - name: Install clusteradm
         run: curl -L https://raw.githubusercontent.com/open-cluster-management-io/clusteradm/main/install.sh | bash
       - name: Create k8s Kind Cluster

--- a/.github/workflows/go-presubmit.yml
+++ b/.github/workflows/go-presubmit.yml
@@ -30,6 +30,23 @@ jobs:
       - name: build
         run: make build
 
+  images-main:
+    name: images-main
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout code
+        uses: actions/checkout@v6
+      - name: images-main
+        run: make images
+      - name: save image artifact
+        run: docker save quay.io/open-cluster-management/managed-serviceaccount:latest -o /tmp/managed-serviceaccount.tar
+      - name: upload image artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: main-image
+          path: /tmp/managed-serviceaccount.tar
+          retention-days: 1
+
   images-cp-creds:
     name: images-cp-creds
     runs-on: ubuntu-latest
@@ -76,6 +93,7 @@ jobs:
 
   e2e:
     name: e2e
+    needs: images-main
     runs-on: ubuntu-latest
     steps:
       - name: checkout code
@@ -84,6 +102,13 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version: ${{ env.GO_VERSION }}
+      - name: download image artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: main-image
+          path: /tmp
+      - name: load main image
+        run: docker load -i /tmp/managed-serviceaccount.tar
       - name: Install clusteradm
         run: curl -L https://raw.githubusercontent.com/open-cluster-management-io/clusteradm/main/install.sh | bash
       - name: Create k8s Kind Cluster
@@ -94,9 +119,8 @@ jobs:
           sh -c "$(cat join.sh) loopback --force-internal-endpoint-lookup"
           clusteradm accept --clusters loopback --wait 30
           kubectl wait --for=condition=ManagedClusterConditionAvailable managedcluster/loopback
-      - name: Build image
+      - name: Load images into kind cluster
         run: |
-          make images
           kind load docker-image quay.io/open-cluster-management/managed-serviceaccount:latest --name chart-testing
       - name: Install latest managed-serviceaccount
         run: |
@@ -112,6 +136,7 @@ jobs:
 
   e2e-addon-template:
     name: e2e-addon-template
+    needs: images-main
     runs-on: ubuntu-latest
     steps:
       - name: checkout code
@@ -120,6 +145,13 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version: ${{ env.GO_VERSION }}
+      - name: download image artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: main-image
+          path: /tmp
+      - name: load main image
+        run: docker load -i /tmp/managed-serviceaccount.tar
       - name: Install clusteradm
         run: curl -L https://raw.githubusercontent.com/open-cluster-management-io/clusteradm/main/install.sh | bash
       - name: Create k8s Kind Cluster
@@ -130,9 +162,8 @@ jobs:
           sh -c "$(cat join.sh) loopback --force-internal-endpoint-lookup"
           clusteradm accept --clusters loopback --wait 30
           kubectl wait --for=condition=ManagedClusterConditionAvailable managedcluster/loopback
-      - name: Build image
+      - name: Load images into kind cluster
         run: |
-          make images
           kind load docker-image quay.io/open-cluster-management/managed-serviceaccount:latest --name chart-testing
       - name: Install latest managed-serviceaccount
         run: |


### PR DESCRIPTION
## Summary

Optimize CI by building the main image separately and sharing it via artifact to e2e jobs, eliminating duplicate builds.

This builds on #307 by separating the image build stage from e2e test execution, so the main image is built once and reused.

## Changes

**Before:**
- `images-cp-creds` job: validates cp-creds Dockerfile
- `e2e` job: builds main image + runs tests
- `e2e-addon-template` job: builds main image again (duplicate) + runs tests

**After:**
- `images-main` job: builds main image, saves as artifact
- `images-cp-creds` job: validates cp-creds Dockerfile (unchanged, runs in parallel)
- `e2e` jobs: download main image artifact, run tests (no rebuild)

## Benefits

✅ **Eliminates duplicate image builds** - main image built once, not twice  
✅ **Validates both Dockerfiles** - cp-creds built in parallel (preserves #307's goal)  
✅ **Minimal wall-clock impact** - only ~1min slower (e2e waits for artifact)  
✅ **Reduced CI compute cost** - less total build time  

## Technical Details

- `images-main` and `images-cp-creds` run in **parallel** (don't block each other)
- E2E jobs only depend on `images-main` (not blocked by cp-creds validation)
- Artifact retention: 1 day
- cp-creds image validated but not artifacted (e2e doesn't use it)

## Related

- Builds on: #307

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

This update contains no user-visible changes. Internal improvements were made to the continuous integration workflow to optimize build efficiency by centralizing Docker image creation and artifact sharing across test jobs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->