### PR TITLE
:seedling: Harden managed-serviceaccount pod security contexts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,3 +8,4 @@ RUN GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-$(go env GOHOSTARCH)} CGO_ENABL
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 COPY --from=builder /go/src/github.com/open-cluster-management.io/managed-serviceaccount/bin/msa /
+USER 65532:65532

--- a/charts/managed-serviceaccount/templates/addontemplate.yaml
+++ b/charts/managed-serviceaccount/templates/addontemplate.yaml
@@ -56,6 +56,10 @@ spec:
               labels:
                 addon-agent: managed-serviceaccount
             spec:
+              securityContext:
+                runAsNonRoot: true
+                seccompProfile:
+                  type: RuntimeDefault
               containers:
               - args:
                 {{- if gt (int .Values.replicas) 1 }}
@@ -69,6 +73,12 @@ spec:
                 - agent
                 image: {{ .Values.image }}:{{ .Values.tag | default (print "v" .Chart.Version) }}
                 imagePullPolicy: IfNotPresent
+                securityContext:
+                  allowPrivilegeEscalation: false
+                  readOnlyRootFilesystem: true
+                  capabilities:
+                    drop:
+                    - ALL
                 livenessProbe:
                   httpGet:
                     path: /healthz

--- a/charts/managed-serviceaccount/templates/manager-deployment.yaml
+++ b/charts/managed-serviceaccount/templates/manager-deployment.yaml
@@ -15,10 +15,20 @@ spec:
         open-cluster-management.io/addon: managed-serviceaccount
     spec:
       serviceAccount: managed-serviceaccount
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: manager
           image: {{ .Values.image }}:{{ .Values.tag | default (print "v" .Chart.Version) }}
           imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+              - ALL
           command:
             - /msa
             - manager

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -11,6 +11,12 @@ spec:
       containers:
       - name: kube-rbac-proxy
         image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+            - ALL
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -24,6 +24,8 @@ spec:
     spec:
       securityContext:
         runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -33,6 +35,10 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+            - ALL
         livenessProbe:
           httpGet:
             path: /healthz

--- a/deploy/bases/addontemplate.yaml
+++ b/deploy/bases/addontemplate.yaml
@@ -43,10 +43,20 @@ spec:
                     addon-agent: managed-serviceaccount
                 spec:
                   serviceAccount: managed-serviceaccount
+                  securityContext:
+                    runAsNonRoot: true
+                    seccompProfile:
+                      type: RuntimeDefault
                   containers:
                     - name: addon-agent
                       image: quay.io/open-cluster-management/managed-serviceaccount:latest
                       imagePullPolicy: IfNotPresent
+                      securityContext:
+                        allowPrivilegeEscalation: false
+                        readOnlyRootFilesystem: true
+                        capabilities:
+                          drop:
+                            - ALL
                       command:
                         - /agent
                       args:

--- a/pkg/addon/manager/addon_test.go
+++ b/pkg/addon/manager/addon_test.go
@@ -5,11 +5,13 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	fakekube "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/utils/ptr"
 	"open-cluster-management.io/addon-framework/pkg/addonfactory"
 	"open-cluster-management.io/addon-framework/pkg/agent"
 	addonv1beta1 "open-cluster-management.io/api/addon/v1beta1"
@@ -194,6 +196,7 @@ func TestManifestAddonAgent(t *testing.T) {
 			assert.NoError(t, err)
 
 			actual := []string{}
+			var agentDeployment *appsv1.Deployment
 			for _, manifest := range manifests {
 				obj, ok := manifest.(metav1.ObjectMetaAccessor)
 				assert.True(t, ok, "invalid manifest")
@@ -201,10 +204,35 @@ func TestManifestAddonAgent(t *testing.T) {
 					assert.Equalf(t, addonName, ns, "unexpected ns of manifest %q", obj.GetObjectMeta().GetName())
 				}
 				actual = append(actual, obj.GetObjectMeta().GetName())
+				if deployment, ok := manifest.(*appsv1.Deployment); ok {
+					agentDeployment = deployment
+				}
 			}
 			assert.ElementsMatch(t, c.expectedManifestNames, actual)
+			if assert.NotNil(t, agentDeployment, "expected addon agent Deployment manifest") {
+				assertAgentSecurityContext(t, agentDeployment)
+			}
 		})
 	}
+}
+
+func assertAgentSecurityContext(t *testing.T, deployment *appsv1.Deployment) {
+	t.Helper()
+
+	podSpec := deployment.Spec.Template.Spec
+	assert.Equal(t, &corev1.PodSecurityContext{
+		RunAsNonRoot:   ptr.To(true),
+		SeccompProfile: &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
+	}, podSpec.SecurityContext)
+
+	if !assert.Len(t, podSpec.Containers, 1, "expected one addon agent container") {
+		return
+	}
+	assert.Equal(t, &corev1.SecurityContext{
+		AllowPrivilegeEscalation: ptr.To(false),
+		ReadOnlyRootFilesystem:   ptr.To(true),
+		Capabilities:             &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
+	}, podSpec.Containers[0].SecurityContext)
 }
 
 func newTestImagePullSecret() *corev1.Secret {

--- a/pkg/addon/manager/manifests/templates/deployment.yaml
+++ b/pkg/addon/manager/manifests/templates/deployment.yaml
@@ -14,6 +14,10 @@ spec:
         addon-agent: managed-serviceaccount
     spec:
       serviceAccountName: managed-serviceaccount
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
 {{- if .NodeSelector }}
       nodeSelector:
       {{- range $key, $value := .NodeSelector }}
@@ -36,6 +40,12 @@ spec:
         - name: addon-agent
           image: {{ .Image }}
           imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+              - ALL
           command:
             - /msa
             - agent


### PR DESCRIPTION
## Summary

- Require managed-serviceaccount manager and addon-agent Pods to run as non-root with RuntimeDefault seccomp.
- Drop all Linux capabilities, disable privilege escalation, and use read-only root filesystems for managed-serviceaccount containers.
- Set the runtime image user to `65532:65532` so `runAsNonRoot` passes kubelet validation.
- Add embedded addon-agent manifest coverage for the hardened pod and container security contexts.

## Related issue(s)

N/A
