### PR TITLE
:seedling: Add Helm chart presubmit checks

### DIFF
--- a/.github/workflows/go-presubmit.yml
+++ b/.github/workflows/go-presubmit.yml
@@ -61,6 +61,21 @@ jobs:
           verbose: true
           fail_ci_if_error: false
 
+  helm:
+    name: helm
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: checkout code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - name: setup helm
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
+      - name: test helm chart
+        run: make test-helm
+
   integration:
     name: integration
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ IMAGE_TAG ?= latest
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
 CRD_OPTIONS ?= "crd:crdVersions={v1},allowDangerousTypes=true,generateEmbeddedObjectMeta=true"
 E2E_TEST_CLUSTER_NAME ?= loopback
+HELM ?= helm
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
@@ -69,6 +70,24 @@ envtest-setup:
 
 test: manifests generate fmt vet envtest-setup ## Run tests.
 	go test ./pkg/... -coverprofile cover.out
+
+.PHONY: test-helm
+test-helm: ## Lint and render Helm chart.
+	$(HELM) lint charts/managed-serviceaccount
+	$(HELM) template managed-serviceaccount charts/managed-serviceaccount \
+		--namespace open-cluster-management-addon >/dev/null
+	$(HELM) template managed-serviceaccount charts/managed-serviceaccount \
+		--namespace open-cluster-management-addon \
+		--set featureGates.ephemeralIdentity=true \
+		--set featureGates.clusterProfile=true >/dev/null
+	$(HELM) template managed-serviceaccount charts/managed-serviceaccount \
+		--namespace open-cluster-management-addon \
+		--set hubDeployMode=AddOnTemplate >/dev/null
+	$(HELM) template managed-serviceaccount charts/managed-serviceaccount \
+		--namespace open-cluster-management-addon \
+		--set hubDeployMode=AddOnTemplate \
+		--set featureGates.ephemeralIdentity=true \
+		--set featureGates.clusterProfile=true >/dev/null
 
 ##@ Build
 


### PR DESCRIPTION
## Summary

- Add a `make test-helm` target that lints and renders the existing managed-serviceaccount Helm chart.
- Exercise the default deployment path, feature-gated rendering, and AddOnTemplate rendering in presubmit.
- Add a dedicated least-privilege `helm` presubmit job to run the chart checks.

## Related issue(s)

None
