### PR TITLE
:seedling: Register authentication API types with runtime schemes

### DIFF
--- a/apis/authentication/v1alpha1/groupversion_info.go
+++ b/apis/authentication/v1alpha1/groupversion_info.go
@@ -20,8 +20,9 @@ limitations under the License.
 package v1alpha1
 
 import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"sigs.k8s.io/controller-runtime/pkg/scheme"
 )
 
 var (
@@ -29,7 +30,7 @@ var (
 	GroupVersion = schema.GroupVersion{Group: "authentication.open-cluster-management.io", Version: "v1alpha1"}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
-	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}
+	SchemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)
 
 	// AddToScheme adds the types in this group-version to the given scheme.
 	AddToScheme = SchemeBuilder.AddToScheme
@@ -39,9 +40,13 @@ var (
 	SchemeGroupVersion = GroupVersion
 )
 
+func addKnownTypes(scheme *runtime.Scheme) error {
+	scheme.AddKnownTypes(GroupVersion, &ManagedServiceAccount{}, &ManagedServiceAccountList{})
+	// AddToGroupVersion allows the serialization of client types like ListOptions.
+	metav1.AddToGroupVersion(scheme, GroupVersion)
+	return nil
+}
+
 func Resource(resource string) schema.GroupResource {
-	return schema.GroupResource{
-		Group:    "authentication.open-cluster-management.io",
-		Resource: resource,
-	}
+	return GroupVersion.WithResource(resource).GroupResource()
 }

--- a/apis/authentication/v1alpha1/managedserviceaccount_types.go
+++ b/apis/authentication/v1alpha1/managedserviceaccount_types.go
@@ -20,10 +20,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func init() {
-	SchemeBuilder.Register(&ManagedServiceAccount{}, &ManagedServiceAccountList{})
-}
-
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
 //+kubebuilder:deprecatedversion:warning="authentication.open-cluster-management.io/v1alpha1 ManagedServiceAccount is deprecated; use authentication.open-cluster-management.io/v1beta1 ManagedServiceAccount; version v1alpha1 will be removed in the next release"

--- a/apis/authentication/v1beta1/groupversion_info.go
+++ b/apis/authentication/v1beta1/groupversion_info.go
@@ -20,8 +20,9 @@ limitations under the License.
 package v1beta1
 
 import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"sigs.k8s.io/controller-runtime/pkg/scheme"
 )
 
 var (
@@ -29,7 +30,7 @@ var (
 	GroupVersion = schema.GroupVersion{Group: "authentication.open-cluster-management.io", Version: "v1beta1"}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
-	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}
+	SchemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)
 
 	// SchemeGroupVersion generated code relies on this name
 	// Deprecated
@@ -39,8 +40,15 @@ var (
 	AddToScheme = SchemeBuilder.AddToScheme
 )
 
+func addKnownTypes(scheme *runtime.Scheme) error {
+	scheme.AddKnownTypes(GroupVersion, &ManagedServiceAccount{}, &ManagedServiceAccountList{})
+	// AddToGroupVersion allows the serialization of client types like ListOptions.
+	metav1.AddToGroupVersion(scheme, GroupVersion)
+	return nil
+}
+
 // Resource generated code relies on this being here, but it logically belongs to the group
 // DEPRECATED
 func Resource(resource string) schema.GroupResource {
-	return schema.GroupResource{Group: GroupVersion.Group, Resource: resource}
+	return GroupVersion.WithResource(resource).GroupResource()
 }

--- a/apis/authentication/v1beta1/managedserviceaccount_types.go
+++ b/apis/authentication/v1beta1/managedserviceaccount_types.go
@@ -20,10 +20,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func init() {
-	SchemeBuilder.Register(&ManagedServiceAccount{}, &ManagedServiceAccountList{})
-}
-
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
 //+kubebuilder:storageversion


### PR DESCRIPTION
## Summary

Avoid relying on package init side effects so runtime schemes consistently include the authentication API types.

## Related issue(s)

N/A

## Tests

- `go test ./apis/authentication/...`
