### PR TITLE
:seedling: Restore install e2e state between cases

### DIFF
--- a/e2e/install/install.go
+++ b/e2e/install/install.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"maps"
+	"slices"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2" //nolint:revive,staticcheck // idiomatic ginkgo usage
@@ -14,7 +16,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -25,21 +26,20 @@ import (
 	"open-cluster-management.io/managed-serviceaccount/pkg/common"
 )
 
-const installTestBasename = "install"
+const (
+	installTestBasename           = "install"
+	installWaitTimeout            = 2 * time.Minute
+	agentDeploymentName           = "managed-serviceaccount-addon-agent"
+	addonDeploymentConfigGroup    = "addon.open-cluster-management.io"
+	addonDeploymentConfigResource = "addondeploymentconfigs"
+	defaultAgentImage             = "quay.io/open-cluster-management/managed-serviceaccount:latest"
+)
 
 var _ = Describe("Addon Installation Test", Label("install"),
 	func() {
 		f := framework.NewE2EFramework(installTestBasename)
 		It("Addon healthiness should work", func() {
-			Eventually(func() (bool, error) {
-				addon := &addonv1alpha1.ManagedClusterAddOn{}
-				err := f.HubRuntimeClient().Get(context.TODO(), types.NamespacedName{
-					Namespace: f.TestClusterName(),
-					Name:      common.AddonName,
-				}, addon)
-				Expect(err).NotTo(HaveOccurred())
-				return meta.IsStatusConditionTrue(addon.Status.Conditions, addonv1alpha1.ManagedClusterAddOnConditionAvailable), nil
-			}).WithTimeout(time.Minute).Should(BeTrue())
+			waitManagedClusterAddonAvailable(f)
 		})
 
 		It("Addon should be configurable with AddOnDeploymentConfig", func() {
@@ -47,7 +47,31 @@ var _ = Describe("Addon Installation Test", Label("install"),
 			nodeSelector := map[string]string{"kubernetes.io/os": "linux"}
 			tolerations := []corev1.Toleration{{Key: "node-role.kubernetes.io/infra", Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoSchedule}}
 
+			waitManagedClusterAddonAvailable(f)
 			c := f.HubRuntimeClient()
+			addon, err := getManagedClusterAddon(c, f.TestClusterName())
+			Expect(err).NotTo(HaveOccurred())
+			originalConfigs := slices.Clone(addon.Spec.Configs)
+			addonInstallNamespace := addon.Status.Namespace
+			agentDeploy, err := getAgentDeployment(f, addonInstallNamespace)
+			Expect(err).NotTo(HaveOccurred())
+			originalNodeSelector := maps.Clone(agentDeploy.Spec.Template.Spec.NodeSelector)
+			originalTolerations := slices.Clone(agentDeploy.Spec.Template.Spec.Tolerations)
+
+			DeferCleanup(func() {
+				By("Restore managed-serviceaccount addon deployment config")
+				Eventually(func() error {
+					return setManagedClusterAddonConfigs(c, f.TestClusterName(), originalConfigs)
+				}).WithTimeout(installWaitTimeout).Should(Succeed())
+				Eventually(func() error {
+					return deleteAddOnDeploymentConfig(c, f.TestClusterName(), deployConfigName)
+				}).WithTimeout(installWaitTimeout).Should(Succeed())
+				waitManagedClusterAddonAvailable(f)
+				waitAgentDeploymentRolledOut(f, addonInstallNamespace, func(deploy *appsv1.Deployment) error {
+					return expectAgentPlacement(deploy, originalNodeSelector, originalTolerations)
+				})
+			})
+
 			By("Prepare a AddOnDeploymentConfig for managed-serviceaccount addon")
 			Eventually(func() error {
 				deployConfigSpec := addonv1alpha1.AddOnDeploymentConfigSpec{
@@ -68,125 +92,74 @@ var _ = Describe("Addon Installation Test", Label("install"),
 					return nil
 				})
 				return err
-			}).WithTimeout(time.Minute).ShouldNot(HaveOccurred())
+			}).WithTimeout(installWaitTimeout).ShouldNot(HaveOccurred())
 
 			By("Add the config to managed-serviceaccount addon")
 			Eventually(func() error {
-				addon := &addonv1alpha1.ManagedClusterAddOn{}
-				if err := c.Get(context.TODO(), types.NamespacedName{
-					Namespace: f.TestClusterName(),
-					Name:      "managed-serviceaccount",
-				}, addon); err != nil {
-					return err
-				}
-
-				addon.Spec.Configs = []addonv1alpha1.AddOnConfig{
-					{
-						ConfigGroupResource: addonv1alpha1.ConfigGroupResource{
-							Group:    "addon.open-cluster-management.io",
-							Resource: "addondeploymentconfigs",
-						},
-						ConfigReferent: addonv1alpha1.ConfigReferent{
-							Namespace: f.TestClusterName(),
-							Name:      deployConfigName,
-						},
-					},
-				}
-
-				return c.Update(context.TODO(), addon)
-			}).WithTimeout(time.Minute).ShouldNot(HaveOccurred())
+				return setManagedClusterAddonConfigs(
+					c,
+					f.TestClusterName(),
+					[]addonv1alpha1.AddOnConfig{addonDeploymentConfigReference(f.TestClusterName(), deployConfigName)},
+				)
+			}).WithTimeout(installWaitTimeout).ShouldNot(HaveOccurred())
 
 			By("Ensure the config is referenced")
 			Eventually(func() error {
-				addon := &addonv1alpha1.ManagedClusterAddOn{}
-				if err := c.Get(context.TODO(), types.NamespacedName{
-					Namespace: f.TestClusterName(),
-					Name:      "managed-serviceaccount",
-				}, addon); err != nil {
+				addon, err := getManagedClusterAddon(c, f.TestClusterName())
+				if err != nil {
 					return err
 				}
 
-				if len(addon.Status.ConfigReferences) == 0 {
-					return fmt.Errorf("no config references in addon status")
-				}
-				found := false
 				for _, ref := range addon.Status.ConfigReferences {
-					if ref.Resource != "addondeploymentconfigs" {
-						continue
+					if ref.Group == addonDeploymentConfigGroup &&
+						ref.Resource == addonDeploymentConfigResource &&
+						ref.Namespace == f.TestClusterName() &&
+						ref.Name == deployConfigName {
+						return nil
 					}
-					if ref.Group != "addon.open-cluster-management.io" {
-						continue
-					}
-					if ref.Name != deployConfigName {
-						return fmt.Errorf("unexpected config references %v", addon.Status.ConfigReferences)
-					}
-					found = true
-				}
-				if !found {
-					return fmt.Errorf("no config references in addon status")
 				}
 
-				return nil
-			}).WithTimeout(time.Minute).ShouldNot(HaveOccurred())
+				return fmt.Errorf("expected config reference %s/%s not found in %v", f.TestClusterName(), deployConfigName, addon.Status.ConfigReferences)
+			}).WithTimeout(installWaitTimeout).ShouldNot(HaveOccurred())
 
 			By("Ensure the managed serviceaccount addon agent is configured")
-			Eventually(func() error {
-				deployments := &appsv1.DeploymentList{}
-				if err := c.List(context.TODO(), deployments, &client.ListOptions{
-					FieldSelector: fields.SelectorFromSet(map[string]string{
-						"metadata.name": "managed-serviceaccount-addon-agent",
-					}),
-				}); err != nil {
-					return err
-				}
-
-				if len(deployments.Items) != 1 {
-					return fmt.Errorf("unexpected number of deployments %v", deployments.Items)
-				}
-				deploy := &deployments.Items[0]
-				if deploy.Status.AvailableReplicas != *deploy.Spec.Replicas {
-					return fmt.Errorf("unexpected available replicas %v", deploy.Status)
-				}
-
-				if !equality.Semantic.DeepEqual(deploy.Spec.Template.Spec.NodeSelector, nodeSelector) {
-					return fmt.Errorf("unexpected nodeSeletcor %v", deploy.Spec.Template.Spec.NodeSelector)
-				}
-
-				if !equality.Semantic.DeepEqual(deploy.Spec.Template.Spec.Tolerations, tolerations) {
-					return fmt.Errorf("unexpected tolerations %v", deploy.Spec.Template.Spec.Tolerations)
-				}
-				return nil
-			}).WithTimeout(time.Minute).ShouldNot(HaveOccurred())
+			waitAgentDeploymentRolledOut(f, addonInstallNamespace, func(deploy *appsv1.Deployment) error {
+				return expectAgentPlacement(deploy, nodeSelector, tolerations)
+			})
 
 			By("Ensure the managed-serviceaccountis available")
-			Eventually(func() error {
-				addon := &addonv1alpha1.ManagedClusterAddOn{}
-				if err := c.Get(context.TODO(), types.NamespacedName{
-					Namespace: f.TestClusterName(),
-					Name:      "managed-serviceaccount",
-				}, addon); err != nil {
-					return err
-				}
-
-				if !meta.IsStatusConditionTrue(
-					addon.Status.Conditions,
-					addonv1alpha1.ManagedClusterAddOnConditionAvailable) {
-					return fmt.Errorf("addon is unavailable")
-				}
-
-				return nil
-			}).WithTimeout(time.Minute).ShouldNot(HaveOccurred())
+			waitManagedClusterAddonAvailable(f)
 		})
 
 		It("Agent image should be overridden by cluster annotation", func() {
+			waitManagedClusterAddonAvailable(f)
+
 			By("Get Addon agent install namespace")
-			addon := &addonv1alpha1.ManagedClusterAddOn{}
-			err := f.HubRuntimeClient().Get(context.TODO(), types.NamespacedName{
-				Namespace: f.TestClusterName(),
-				Name:      common.AddonName,
-			}, addon)
+			addon, err := getManagedClusterAddon(f.HubRuntimeClient(), f.TestClusterName())
 			Expect(err).NotTo(HaveOccurred())
 			addonInstallNamespace := addon.Status.Namespace
+
+			cluster := &clusterv1.ManagedCluster{}
+			err = f.HubRuntimeClient().Get(context.TODO(), types.NamespacedName{Name: f.TestClusterName()}, cluster)
+			Expect(err).NotTo(HaveOccurred())
+			originalImageRegistriesAnnotation, hadOriginalImageRegistriesAnnotation :=
+				cluster.Annotations[clusterv1.ClusterImageRegistriesAnnotationKey]
+
+			DeferCleanup(func() {
+				By("Restore the managed cluster annotation")
+				Eventually(func() error {
+					return restoreManagedClusterImageRegistriesAnnotation(
+						f.HubRuntimeClient(),
+						f.TestClusterName(),
+						originalImageRegistriesAnnotation,
+						hadOriginalImageRegistriesAnnotation,
+					)
+				}).WithTimeout(installWaitTimeout).Should(Succeed())
+				waitAgentDeploymentRolledOut(f, addonInstallNamespace, func(deploy *appsv1.Deployment) error {
+					return expectAgentImage(deploy, defaultAgentImage)
+				})
+				waitManagedClusterAddonAvailable(f)
+			})
 
 			By("Prepare cluster annotation for addon image override config")
 			overrideRegistries := addonv1alpha1.AddOnDeploymentConfigSpec{
@@ -200,82 +173,171 @@ var _ = Describe("Addon Installation Test", Label("install"),
 			registriesJSON, err := json.Marshal(overrideRegistries)
 			Expect(err).ToNot(HaveOccurred())
 			Eventually(func() error {
-				cluster := &clusterv1.ManagedCluster{}
-				err := f.HubRuntimeClient().Get(context.Background(),
-					types.NamespacedName{Name: f.TestClusterName()},
-					cluster)
-				if err != nil {
-					return err
-				}
-
-				newCluster := cluster.DeepCopy()
-
-				annotations := cluster.Annotations
-				if annotations == nil {
-					annotations = make(map[string]string)
-				}
-				annotations[clusterv1.ClusterImageRegistriesAnnotationKey] = string(registriesJSON)
-
-				newCluster.Annotations = annotations
-				return f.HubRuntimeClient().Update(context.Background(), newCluster)
-			}).WithTimeout(time.Minute).ShouldNot(HaveOccurred())
+				return setManagedClusterImageRegistriesAnnotation(
+					f.HubRuntimeClient(),
+					f.TestClusterName(),
+					string(registriesJSON),
+				)
+			}).WithTimeout(installWaitTimeout).ShouldNot(HaveOccurred())
 
 			By("Make sure addon is configured")
 			Eventually(func() error {
-				agentDeploy, err := f.HubNativeClient().AppsV1().Deployments(addonInstallNamespace).Get(
-					context.Background(), "managed-serviceaccount-addon-agent", metav1.GetOptions{})
+				agentDeploy, err := getAgentDeployment(f, addonInstallNamespace)
 				if err != nil {
 					return err
 				}
 
-				containers := agentDeploy.Spec.Template.Spec.Containers
-				if len(containers) != 1 {
-					return fmt.Errorf("expect one container, but %v", containers)
-				}
-
-				if containers[0].Image != "quay.io/ocm/managed-serviceaccount:latest" {
-					return fmt.Errorf("unexpected image %s", containers[0].Image)
-				}
-
-				return nil
-			}).WithTimeout(time.Minute).ShouldNot(HaveOccurred())
-
-			// restore the image override config, because the override image is not available
-			// but it is needed by the pre-delete job
-			By("Restore the managed cluster annotation")
-			Eventually(func() error {
-				cluster := &clusterv1.ManagedCluster{}
-				err := f.HubRuntimeClient().Get(context.Background(),
-					types.NamespacedName{Name: f.TestClusterName()},
-					cluster)
-				if err != nil {
-					return err
-				}
-
-				newCluster := cluster.DeepCopy()
-				delete(newCluster.Annotations, clusterv1.ClusterImageRegistriesAnnotationKey)
-				return f.HubRuntimeClient().Update(context.Background(), newCluster)
-			}).WithTimeout(time.Minute).ShouldNot(HaveOccurred())
-
-			By("Make sure addon config is restored")
-			Eventually(func() error {
-				agentDeploy, err := f.HubNativeClient().AppsV1().Deployments(addonInstallNamespace).Get(
-					context.Background(), "managed-serviceaccount-addon-agent", metav1.GetOptions{})
-				if err != nil {
-					return err
-				}
-
-				containers := agentDeploy.Spec.Template.Spec.Containers
-				if len(containers) != 1 {
-					return fmt.Errorf("expect one container, but %v", containers)
-				}
-
-				if containers[0].Image != "quay.io/open-cluster-management/managed-serviceaccount:latest" {
-					return fmt.Errorf("unexpected image %s", containers[0].Image)
-				}
-
-				return nil
-			}).WithTimeout(time.Minute).ShouldNot(HaveOccurred())
+				return expectAgentImage(agentDeploy, "quay.io/ocm/managed-serviceaccount:latest")
+			}).WithTimeout(installWaitTimeout).ShouldNot(HaveOccurred())
 		})
 
 	})
+
+func getManagedClusterAddon(c client.Client, clusterName string) (*addonv1alpha1.ManagedClusterAddOn, error) {
+	addon := &addonv1alpha1.ManagedClusterAddOn{}
+	err := c.Get(context.TODO(), types.NamespacedName{
+		Namespace: clusterName,
+		Name:      common.AddonName,
+	}, addon)
+	return addon, err
+}
+
+func waitManagedClusterAddonAvailable(f framework.Framework) {
+	Eventually(func() error {
+		addon, err := getManagedClusterAddon(f.HubRuntimeClient(), f.TestClusterName())
+		if err != nil {
+			return err
+		}
+		if !meta.IsStatusConditionTrue(addon.Status.Conditions, addonv1alpha1.ManagedClusterAddOnConditionAvailable) {
+			return fmt.Errorf("addon is unavailable: %v", addon.Status.Conditions)
+		}
+		return nil
+	}).WithTimeout(installWaitTimeout).Should(Succeed())
+}
+
+func setManagedClusterAddonConfigs(c client.Client, clusterName string, configs []addonv1alpha1.AddOnConfig) error {
+	addon, err := getManagedClusterAddon(c, clusterName)
+	if err != nil {
+		return err
+	}
+	addon.Spec.Configs = configs
+	return c.Update(context.TODO(), addon)
+}
+
+func addonDeploymentConfigReference(namespace, name string) addonv1alpha1.AddOnConfig {
+	return addonv1alpha1.AddOnConfig{
+		ConfigGroupResource: addonv1alpha1.ConfigGroupResource{
+			Group:    addonDeploymentConfigGroup,
+			Resource: addonDeploymentConfigResource,
+		},
+		ConfigReferent: addonv1alpha1.ConfigReferent{
+			Namespace: namespace,
+			Name:      name,
+		},
+	}
+}
+
+func deleteAddOnDeploymentConfig(c client.Client, namespace, name string) error {
+	return client.IgnoreNotFound(c.Delete(context.TODO(), &addonv1alpha1.AddOnDeploymentConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+		},
+	}))
+}
+
+func setManagedClusterImageRegistriesAnnotation(c client.Client, clusterName, value string) error {
+	cluster := &clusterv1.ManagedCluster{}
+	if err := c.Get(context.TODO(), types.NamespacedName{Name: clusterName}, cluster); err != nil {
+		return err
+	}
+
+	clusterCopy := cluster.DeepCopy()
+	annotations := maps.Clone(cluster.Annotations)
+	if annotations == nil {
+		annotations = map[string]string{}
+	}
+	annotations[clusterv1.ClusterImageRegistriesAnnotationKey] = value
+	clusterCopy.Annotations = annotations
+	return c.Update(context.TODO(), clusterCopy)
+}
+
+func restoreManagedClusterImageRegistriesAnnotation(c client.Client, clusterName, value string, exists bool) error {
+	cluster := &clusterv1.ManagedCluster{}
+	if err := c.Get(context.TODO(), types.NamespacedName{Name: clusterName}, cluster); err != nil {
+		return err
+	}
+
+	clusterCopy := cluster.DeepCopy()
+	annotations := maps.Clone(cluster.Annotations)
+	if exists {
+		if annotations == nil {
+			annotations = map[string]string{}
+		}
+		annotations[clusterv1.ClusterImageRegistriesAnnotationKey] = value
+	} else {
+		delete(annotations, clusterv1.ClusterImageRegistriesAnnotationKey)
+	}
+	if len(annotations) == 0 {
+		annotations = nil
+	}
+	clusterCopy.Annotations = annotations
+	return c.Update(context.TODO(), clusterCopy)
+}
+
+func getAgentDeployment(f framework.Framework, namespace string) (*appsv1.Deployment, error) {
+	return f.HubNativeClient().AppsV1().Deployments(namespace).Get(
+		context.TODO(), agentDeploymentName, metav1.GetOptions{})
+}
+
+func waitAgentDeploymentRolledOut(f framework.Framework, namespace string, validate func(*appsv1.Deployment) error) {
+	Eventually(func() error {
+		deploy, err := getAgentDeployment(f, namespace)
+		if err != nil {
+			return err
+		}
+		if err := agentDeploymentRolledOut(deploy); err != nil {
+			return err
+		}
+		return validate(deploy)
+	}).WithTimeout(installWaitTimeout).Should(Succeed())
+}
+
+func agentDeploymentRolledOut(deploy *appsv1.Deployment) error {
+	replicas := int32(1)
+	if deploy.Spec.Replicas != nil {
+		replicas = *deploy.Spec.Replicas
+	}
+	if deploy.Generation > deploy.Status.ObservedGeneration {
+		return fmt.Errorf("deployment generation %d has not been observed, status observed generation is %d",
+			deploy.Generation, deploy.Status.ObservedGeneration)
+	}
+	if deploy.Status.UpdatedReplicas != replicas ||
+		deploy.Status.ReadyReplicas != replicas ||
+		deploy.Status.AvailableReplicas != replicas ||
+		deploy.Status.UnavailableReplicas != 0 {
+		return fmt.Errorf("deployment %s is not rolled out: %v", deploy.Name, deploy.Status)
+	}
+	return nil
+}
+
+func expectAgentImage(deploy *appsv1.Deployment, image string) error {
+	containers := deploy.Spec.Template.Spec.Containers
+	if len(containers) != 1 {
+		return fmt.Errorf("expect one container, but %v", containers)
+	}
+	if containers[0].Image != image {
+		return fmt.Errorf("unexpected image %s", containers[0].Image)
+	}
+	return nil
+}
+
+func expectAgentPlacement(deploy *appsv1.Deployment, nodeSelector map[string]string, tolerations []corev1.Toleration) error {
+	if !equality.Semantic.DeepEqual(deploy.Spec.Template.Spec.NodeSelector, nodeSelector) {
+		return fmt.Errorf("unexpected nodeSelector %v", deploy.Spec.Template.Spec.NodeSelector)
+	}
+	if !equality.Semantic.DeepEqual(deploy.Spec.Template.Spec.Tolerations, tolerations) {
+		return fmt.Errorf("unexpected tolerations %v", deploy.Spec.Template.Spec.Tolerations)
+	}
+	return nil
+}

--- a/e2e/install/install.go
+++ b/e2e/install/install.go
@@ -42,7 +42,7 @@ var _ = Describe("Addon Installation Test", Label("install"),
 			waitManagedClusterAddonAvailable(f)
 		})
 
-		It("Addon should be configurable with AddOnDeploymentConfig", func() {
+		It("Addon can be configured with AddOnDeploymentConfig", func() {
 			deployConfigName := "tolerations-deploy-config"
 			nodeSelector := map[string]string{"kubernetes.io/os": "linux"}
 			tolerations := []corev1.Toleration{{Key: "node-role.kubernetes.io/infra", Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoSchedule}}
@@ -127,7 +127,7 @@ var _ = Describe("Addon Installation Test", Label("install"),
 				return expectAgentPlacement(deploy, nodeSelector, tolerations)
 			})
 
-			By("Ensure the managed-serviceaccountis available")
+			By("Ensure the managed-serviceaccount is available")
 			waitManagedClusterAddonAvailable(f)
 		})
 


### PR DESCRIPTION
## Summary

Prevent install e2e cases from leaking mutated addon state into later cases and presubmit teardown.

## Related issue(s)

N/A

## Tests

- `go test -c ./e2e/install`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced end-to-end test reliability and maintainability by consolidating repeated test logic into shared helper functions and standardizing timeout configurations.

---

**Note:** This is an internal testing infrastructure improvement with no user-visible changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->