### PR TITLE
:seedling: allow release PR title prefix

### DIFF
--- a/.github/workflows/pr-verify.yml
+++ b/.github/workflows/pr-verify.yml
@@ -26,7 +26,7 @@ jobs:
             exit 1
           fi
 
-          if ! [[ "$TITLE" =~ ^(:sparkles:|:bug:|:book:|:memo:|:warning:|:seedling:|:question:|$'\u2728'|$'\U0001F41B'|$'\U0001F4D6'|$'\U0001F4DD'|$'\u26A0'$'\uFE0F'?|$'\U0001F331'|$'\u2753') ]]; then
+          if ! [[ "$TITLE" =~ ^(:sparkles:|:bug:|:book:|:memo:|:warning:|:rocket:|:seedling:|:question:|$'\u2728'|$'\U0001F41B'|$'\U0001F4D6'|$'\U0001F4DD'|$'\u26A0'$'\uFE0F'?|$'\U0001F680'|$'\U0001F331'|$'\u2753') ]]; then
             echo "Error: Invalid PR title format."
             echo "Your PR title must start with one of the following indicators:"
             echo "- :sparkles: ✨ feature"
@@ -34,6 +34,7 @@ jobs:
             echo "- :book: 📖 docs"
             echo "- :memo: 📝 proposal"
             echo "- :warning: ⚠️ breaking change"
+            echo "- :rocket: 🚀 release"
             echo "- :seedling: 🌱 other/misc"
             echo "- :question: ❓ requires manual review"
             exit 1


### PR DESCRIPTION
## Summary
- Allow release PR titles to use the `:rocket:` textual prefix in PR verifier.
- Allow the matching `🚀` emoji prefix.
- Add the release entry to the verifier error message so it matches the PR template.

## Why
The PR template already advertises `:rocket: 🚀 release`, but `.github/workflows/pr-verify.yml` rejected that prefix. This aligns the automated check with the documented title options.

## Validation
- `git diff --check`
- Verified the title regex accepts `:rocket: release`, `🚀 release`, existing `:seedling:` and `✨` prefixes, and still rejects `:construction:`.