### PR TITLE
:seedling: Remove release prefix from PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,7 +10,6 @@ Please copy the appropriate `:text:` or icon to the beginning of your PR title:
 :book: 📖 docs
 :memo: 📝 proposal
 :warning: ⚠️ breaking change
-:rocket: 🚀 release
 :seedling: 🌱 other/misc
 :question: ❓ requires manual review/categorization
 


### PR DESCRIPTION
## Summary

Remove the `:rocket: 🚀 release` option from the PR title guidance.

## Why

The repository already rejects rocket-prefixed PR titles in `pr-verify.yml`, and this aligns the PR template with open-cluster-management-io/ocm.

Follow-up to review feedback on #326: https://github.com/open-cluster-management-io/managed-serviceaccount/pull/326#issuecomment-4768824318

## Validation

- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pull request template configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->