### PR TITLE
:seedling: Allow CGO_ENABLED override in make targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ GOBIN=$(shell go env GOBIN)
 endif
 
 export DOCKER_BUILDER ?= docker
-export CGO_ENABLED = 0
+export CGO_ENABLED ?= 1
 export GOFLAGS ?=
 GO_BUILD_FLAGS ?= -a
 GO_BUILD_LDFLAGS ?=


### PR DESCRIPTION
- previous value was CGO_ENABLED=1, which we need for some builds.
- Note that the current Dockerfile already specifically sets CGO_ENABLED=0 before running `make build-bin` so the Dockerfile behavior remains unchanged.

<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

## Related issue(s)

Fixes #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the default build configuration to enable CGO.
  * Added support for overriding the CGO setting through the environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->