### PR TITLE
:sparkles: Add opt-in NetworkPolicies for hub manager and addon agent

### DIFF
--- a/charts/managed-serviceaccount/templates/addontemplate.yaml
+++ b/charts/managed-serviceaccount/templates/addontemplate.yaml
@@ -107,6 +107,47 @@ spec:
             port: 38080
             targetPort: metrics
             protocol: TCP
+{{- if .Values.networkPolicies.enabled }}
+      - apiVersion: networking.k8s.io/v1
+        kind: NetworkPolicy
+        metadata:
+          name: managed-serviceaccount-addon-agent-network-policy
+          namespace: open-cluster-management-agent-addon
+          labels:
+            addon-agent: managed-serviceaccount
+        spec:
+          podSelector:
+            matchLabels:
+              addon-agent: managed-serviceaccount
+          policyTypes:
+          - Ingress
+          - Egress
+          ingress:
+          # kubelet livenessProbe /healthz
+          - ports:
+            - protocol: TCP
+              port: 8000
+          {{- if .Values.prometheus.enabled }}
+          - ports:
+            - protocol: TCP
+              port: 38080
+          {{- end }}
+          egress:
+          - ports:
+            - protocol: UDP
+              port: 53
+            - protocol: TCP
+              port: 53
+            - protocol: UDP
+              port: 5353
+            - protocol: TCP
+              port: 5353
+          - ports:
+            - protocol: TCP
+              port: 443
+            - protocol: TCP
+              port: 6443
+{{- end }}
 {{- if .Values.prometheus.enabled }}
       - apiVersion: monitoring.coreos.com/v1
         kind: ServiceMonitor

--- a/charts/managed-serviceaccount/templates/manager-deployment.yaml
+++ b/charts/managed-serviceaccount/templates/manager-deployment.yaml
@@ -40,6 +40,7 @@ spec:
             - --deploy-mode={{ .Values.hubDeployMode }}
             - --metrics-bind-address=:38080
             - --agent-image-name={{ $image }}
+            - --enable-network-policies={{ .Values.networkPolicies.enabled }}
             {{- if .Values.featureGates }}
             - --feature-gates=EphemeralIdentity={{ .Values.featureGates.ephemeralIdentity | default false}},ClusterProfile={{ .Values.featureGates.clusterProfile | default false}}
             {{- end }}

--- a/charts/managed-serviceaccount/templates/manager-networkpolicy.yaml
+++ b/charts/managed-serviceaccount/templates/manager-networkpolicy.yaml
@@ -1,0 +1,41 @@
+{{- if and .Values.networkPolicies.enabled (include "managed-serviceaccount.hubManager.enabled" .) }}
+# Purpose: Default-deny for managed-serviceaccount addon-manager, then allow
+# DNS and Kubernetes API egress. Metrics ingress (:38080) is allowed only when
+# prometheus is enabled. Peers are port-based (empty "to"/"from") for
+# portability across Kubernetes vendors.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: managed-serviceaccount-addon-manager-network-policy
+  namespace: {{ .Release.Namespace }}
+spec:
+  podSelector:
+    matchLabels:
+      open-cluster-management.io/addon: managed-serviceaccount
+  policyTypes:
+  - Ingress
+  - Egress
+  {{- if .Values.prometheus.enabled }}
+  ingress:
+  - ports:
+    - protocol: TCP
+      port: 38080
+  {{- end }}
+  egress:
+  # DNS (:53 common; :5353 used by some distributions)
+  - ports:
+    - protocol: UDP
+      port: 53
+    - protocol: TCP
+      port: 53
+    - protocol: UDP
+      port: 5353
+    - protocol: TCP
+      port: 5353
+  # Kubernetes API
+  - ports:
+    - protocol: TCP
+      port: 443
+    - protocol: TCP
+      port: 6443
+{{- end }}

--- a/charts/managed-serviceaccount/values.yaml
+++ b/charts/managed-serviceaccount/values.yaml
@@ -26,3 +26,12 @@ hubDeployMode: Deployment
 
 # Name of the managed service-account addon template, only used when hubDeployMode is AddOnTemplate
 addOnTemplateName: managed-serviceaccount
+
+# Opt-in NetworkPolicies for the hub addon-manager and the managed-cluster
+# addon-agent (via manager flag --enable-network-policies, or embedded in
+# AddOnTemplate when hubDeployMode=AddOnTemplate). Default false so community
+# installs are unchanged. Policies use port-based peers for portability across
+# Kubernetes vendors. Metrics ingress (:38080) is opened only when prometheus
+# is enabled.
+networkPolicies:
+  enabled: false

--- a/cmd/manager/manager.go
+++ b/cmd/manager/manager.go
@@ -106,17 +106,20 @@ func (o *HubManagerOptions) AddFlags(flags *pflag.FlagSet) {
 		"The image pull secret that addon agent will use. "+
 			"When specified, the content of image pull secret in the manager namespace on hub will be copied to the agent namespace on the managed cluster."+
 			"This can also be configured with environment variable AGENT_IMAGE_PULL_SECRET.")
+	flags.BoolVar(&o.EnableNetworkPolicies, "enable-network-policies", false,
+		"Enable NetworkPolicies for the managed-cluster managed-serviceaccount addon-agent")
 }
 
 // HubManagerOptions holds configuration for hub manager controller
 type HubManagerOptions struct {
-	MetricsAddr          string
-	EnableLeaderElection bool
-	ProbeAddr            string
-	AddonAgentImageName  string
-	ImagePullSecretName  string
-	DeployMode           string
-	FeatureGatesFlags    map[string]bool
+	MetricsAddr           string
+	EnableLeaderElection  bool
+	ProbeAddr             string
+	AddonAgentImageName   string
+	ImagePullSecretName   string
+	DeployMode            string
+	FeatureGatesFlags     map[string]bool
+	EnableNetworkPolicies bool
 }
 
 // NewHubManagerOptions returns a HubManagerOptions
@@ -215,7 +218,7 @@ func (o *HubManagerOptions) Run() error {
 			WithScheme(manager.NewAgentScheme()).
 			WithConfigGVRs(utils.AddOnDeploymentConfigGVR).
 			WithGetValuesFuncs(
-				manager.GetDefaultValues(o.AddonAgentImageName, imagePullSecret),
+				manager.GetDefaultValues(o.AddonAgentImageName, imagePullSecret, o.EnableNetworkPolicies),
 				addonfactory.GetAgentImageValues(
 					utils.NewAddOnDeploymentConfigGetter(addonClient),
 					"Image",

--- a/pkg/addon/manager/addon.go
+++ b/pkg/addon/manager/addon.go
@@ -57,10 +57,13 @@ func NewAgentScheme() *runtime.Scheme {
 	return s
 }
 
-func GetDefaultValues(image string, imagePullSecret *corev1.Secret) addonfactory.GetValuesFunc {
+func GetDefaultValues(image string, imagePullSecret *corev1.Secret, enableNetworkPolicies bool) addonfactory.GetValuesFunc {
 	return func(_ *clusterv1.ManagedCluster, _ *addonv1beta1.ManagedClusterAddOn) (addonfactory.Values, error) {
 		values := addonfactory.Values{
 			"Image": image,
+			"networkPolicies": map[string]interface{}{
+				"enabled": enableNetworkPolicies,
+			},
 		}
 
 		if imagePullSecret != nil {

--- a/pkg/addon/manager/addon_test.go
+++ b/pkg/addon/manager/addon_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -184,20 +185,20 @@ func TestManifestAddonAgent(t *testing.T) {
 	}{
 		{
 			name:                  "install",
-			getValuesFunc:         []addonfactory.GetValuesFunc{GetDefaultValues(imageName, nil)},
+			getValuesFunc:         []addonfactory.GetValuesFunc{GetDefaultValues(imageName, nil, false)},
 			expectedManifestNames: manifestNames,
 			expectedImage:         imageName,
 		},
 		{
 			name:                  "install all with image pull secret",
-			getValuesFunc:         []addonfactory.GetValuesFunc{GetDefaultValues(imageName, newTestImagePullSecret())},
+			getValuesFunc:         []addonfactory.GetValuesFunc{GetDefaultValues(imageName, newTestImagePullSecret(), false)},
 			expectedManifestNames: append(manifestNames, "open-cluster-management-image-pull-credentials"),
 			expectedImage:         imageName,
 		},
 		{
 			name: "node placement is rendered on the agent deployment",
 			getValuesFunc: []addonfactory.GetValuesFunc{
-				GetDefaultValues(imageName, nil),
+				GetDefaultValues(imageName, nil, false),
 				getNodePlacementValues(
 					map[string]string{"kubernetes.io/os": "linux"},
 					[]corev1.Toleration{{Key: "foo", Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoExecute}},
@@ -290,7 +291,7 @@ func TestGetDefaultValuesRequiresDockerConfigJsonKey(t *testing.T) {
 			imagePullSecret := newTestImagePullSecret()
 			imagePullSecret.Data = c.data
 
-			values, err := GetDefaultValues("imageName1", imagePullSecret)(newTestCluster("cluster1"), newTestAddOn(common.AddonName, "cluster1"))
+			values, err := GetDefaultValues("imageName1", imagePullSecret, false)(newTestCluster("cluster1"), newTestAddOn(common.AddonName, "cluster1"))
 
 			assert.Nil(t, values)
 			assert.ErrorContains(t, err, `missing ".dockerconfigjson"`)
@@ -365,7 +366,7 @@ func TestManifestAddonServiceMonitor(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			manifests := renderWithConfig(t, clusterName, "addon1", "imageName1", c.variables...)
+			manifests := renderWithConfig(t, clusterName, "addon1", "imageName1", false, c.variables...)
 
 			var serviceMonitor *unstructured.Unstructured
 			for _, manifest := range manifests {
@@ -381,6 +382,68 @@ func TestManifestAddonServiceMonitor(t *testing.T) {
 				assert.Equal(t, "managed-serviceaccount-addon-agent", serviceMonitor.GetName())
 				assert.Equal(t, c.expectedLabels, serviceMonitor.GetLabels())
 			}
+		})
+	}
+}
+
+func TestManifestAddonNetworkPolicy(t *testing.T) {
+	clusterName := "cluster1"
+	addonName := "addon1"
+	imageName := "imageName1"
+
+	cases := []struct {
+		name                  string
+		enableNetworkPolicies bool
+		prometheusEnabled     bool
+		expectNetworkPolicy   bool
+		expectMetricsIngress  bool
+	}{
+		{
+			name:                  "disabled by default",
+			enableNetworkPolicies: false,
+			expectNetworkPolicy:   false,
+		},
+		{
+			name:                  "enabled without prometheus has no metrics ingress",
+			enableNetworkPolicies: true,
+			expectNetworkPolicy:   true,
+			expectMetricsIngress:  false,
+		},
+		{
+			name:                  "enabled with prometheus opens metrics ingress",
+			enableNetworkPolicies: true,
+			prometheusEnabled:     true,
+			expectNetworkPolicy:   true,
+			expectMetricsIngress:  true,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			var variables []addonv1beta1.CustomizedVariable
+			if c.prometheusEnabled {
+				variables = []addonv1beta1.CustomizedVariable{
+					{Name: prometheusEnabledVariableName, Value: "true"},
+				}
+			}
+			manifests := renderWithConfig(t, clusterName, addonName, imageName, c.enableNetworkPolicies, variables...)
+
+			np := getAgentNetworkPolicy(manifests)
+			if !c.expectNetworkPolicy {
+				assert.Nil(t, np, "NetworkPolicy should not be rendered when disabled")
+				return
+			}
+			if !assert.NotNil(t, np, "expected agent NetworkPolicy") {
+				return
+			}
+			assert.Equal(t, "managed-serviceaccount-addon-agent-network-policy", np.Name)
+			assert.Contains(t, np.Spec.PolicyTypes, networkingv1.PolicyTypeIngress)
+			assert.Contains(t, np.Spec.PolicyTypes, networkingv1.PolicyTypeEgress)
+			assert.True(t, networkPolicyAllowsEgressTCPPort(np, 443))
+			assert.True(t, networkPolicyAllowsEgressTCPPort(np, 6443))
+			hasMetricsIngress := networkPolicyAllowsIngressTCPPort(np, 38080)
+			assert.Equal(t, c.expectMetricsIngress, hasMetricsIngress)
+			assert.True(t, networkPolicyAllowsIngressTCPPort(np, 8000),
+				"health :8000 must be opened for kubelet livenessProbe")
 		})
 	}
 }
@@ -435,7 +498,7 @@ func renderTestManifests(
 	return manifests
 }
 
-func renderWithConfig(t *testing.T, clusterName, addonName, imageName string, variables ...addonv1beta1.CustomizedVariable) []runtime.Object {
+func renderWithConfig(t *testing.T, clusterName, addonName, imageName string, enableNetworkPolicies bool, variables ...addonv1beta1.CustomizedVariable) []runtime.Object {
 	t.Helper()
 	config := &addonv1beta1.AddOnDeploymentConfig{
 		ObjectMeta: metav1.ObjectMeta{
@@ -467,13 +530,64 @@ func renderWithConfig(t *testing.T, clusterName, addonName, imageName string, va
 		t,
 		newTestCluster(clusterName),
 		addon,
-		GetDefaultValues(imageName, nil),
+		GetDefaultValues(imageName, nil, enableNetworkPolicies),
 		addonfactory.GetAddOnDeploymentConfigValues(
 			utils.NewAddOnDeploymentConfigGetter(fakeaddon.NewSimpleClientset(config)),
 			addonfactory.ToAddOnDeploymentConfigValues,
 			ToAddOnPrometheusValues,
 		),
 	)
+}
+
+func getAgentNetworkPolicy(manifests []runtime.Object) *networkingv1.NetworkPolicy {
+	for _, manifest := range manifests {
+		if np, ok := manifest.(*networkingv1.NetworkPolicy); ok {
+			if np.Name == "managed-serviceaccount-addon-agent-network-policy" {
+				return np
+			}
+		}
+	}
+	return nil
+}
+
+func networkPolicyAllowsEgressTCPPort(np *networkingv1.NetworkPolicy, port int32) bool {
+	if np == nil {
+		return false
+	}
+	for _, rule := range np.Spec.Egress {
+		if len(rule.Ports) == 0 {
+			continue
+		}
+		for _, p := range rule.Ports {
+			if p.Protocol != nil && *p.Protocol != corev1.ProtocolTCP {
+				continue
+			}
+			if p.Port != nil && p.Port.IntVal == port {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func networkPolicyAllowsIngressTCPPort(np *networkingv1.NetworkPolicy, port int32) bool {
+	if np == nil {
+		return false
+	}
+	for _, rule := range np.Spec.Ingress {
+		if len(rule.Ports) == 0 {
+			continue
+		}
+		for _, p := range rule.Ports {
+			if p.Protocol != nil && *p.Protocol != corev1.ProtocolTCP {
+				continue
+			}
+			if p.Port != nil && p.Port.IntVal == port {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func newTestImagePullSecret() *corev1.Secret {

--- a/pkg/addon/manager/manifests/charts/managed-serviceaccount-agent/templates/agent-networkpolicy.yaml
+++ b/pkg/addon/manager/manifests/charts/managed-serviceaccount-agent/templates/agent-networkpolicy.yaml
@@ -1,0 +1,51 @@
+{{- if .Values.networkPolicies.enabled }}
+# Purpose: Default-deny for managed-serviceaccount-addon-agent on the managed
+# cluster, then allow required egress (DNS + hub/spoke API). Health ingress
+# (:8000) allows kubelet livenessProbe /healthz. Metrics ingress (:38080) is
+# allowed only when Prometheus is enabled. Peers are port-based (empty
+# "to"/"from") for portability across Kubernetes vendors. Enabled when the hub
+# addon-manager runs with --enable-network-policies=true (from
+# charts/managed-serviceaccount values networkPolicies.enabled), or when
+# embedded in AddOnTemplate with the same chart value.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: managed-serviceaccount-addon-agent-network-policy
+  namespace: {{ .Values.addonInstallNamespace }}
+  labels:
+    addon-agent: managed-serviceaccount
+spec:
+  podSelector:
+    matchLabels:
+      addon-agent: managed-serviceaccount
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress:
+  # kubelet livenessProbe /healthz
+  - ports:
+    - protocol: TCP
+      port: 8000
+  {{- if .Values.Prometheus.Enabled }}
+  - ports:
+    - protocol: TCP
+      port: 38080
+  {{- end }}
+  egress:
+  # DNS (:53 common; :5353 used by some distributions)
+  - ports:
+    - protocol: UDP
+      port: 53
+    - protocol: TCP
+      port: 53
+    - protocol: UDP
+      port: 5353
+    - protocol: TCP
+      port: 5353
+  # Hub kubeconfig API and spoke kube-apiserver
+  - ports:
+    - protocol: TCP
+      port: 443
+    - protocol: TCP
+      port: 6443
+{{- end }}

--- a/pkg/addon/manager/manifests/charts/managed-serviceaccount-agent/values.yaml
+++ b/pkg/addon/manager/manifests/charts/managed-serviceaccount-agent/values.yaml
@@ -17,3 +17,8 @@ Prometheus:
   Enabled: false
   ServiceMonitor:
     Labels: {}
+
+# Set by the hub addon-manager from --enable-network-policies
+# (charts/managed-serviceaccount values networkPolicies.enabled).
+networkPolicies:
+  enabled: false


### PR DESCRIPTION
## Summary
- Add opt-in NetworkPolicies for the hub addon-manager and managed-cluster addon-agent, following the same pattern as [cluster-proxy#334](https://github.com/open-cluster-management-io/cluster-proxy/pull/334).
- Policies are default-deny with port-based peers (DNS `:53`/`:5353`, API `:443`/`:6443`); metrics ingress (`:38080`) opens only when Prometheus is enabled. Health `:8000` is not opened.
- Gated by `networkPolicies.enabled` / `--enable-network-policies` (default `false`) so community installs are unchanged. Covered for both Deployment and AddOnTemplate hub deploy modes.

## Test plan
- [x] `go test ./pkg/addon/manager/` (includes new `TestManifestAddonNetworkPolicy` cases)
- [ ] Install chart with `networkPolicies.enabled=false` (default) and confirm no NetworkPolicies are created
- [ ] Enable `networkPolicies.enabled=true` and verify hub manager NetworkPolicy + agent NetworkPolicy (via manager flag or AddOnTemplate)
- [ ] With Prometheus enabled, confirm metrics ingress `:38080` is allowed; without it, confirm no metrics ingress
- [ ] Confirm agent can still reach hub/spoke API and DNS under the policy


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional Kubernetes NetworkPolicies for the managed service account manager and agent.
  * Network policies restrict traffic to required DNS and Kubernetes API ports.
  * Prometheus metrics traffic is allowed on port 38080 when monitoring is enabled.
  * Added the `--enable-network-policies` option, disabled by default.

* **Tests**
  * Added coverage validating NetworkPolicy creation and allowed ingress and egress ports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->