### PR TITLE
:bug: Add delete verb to secrets RBAC for ownerReference updates

### DIFF
--- a/charts/managed-serviceaccount/templates/agent-registration-clusterrole.yaml
+++ b/charts/managed-serviceaccount/templates/agent-registration-clusterrole.yaml
@@ -14,6 +14,7 @@ rules:
   - watch
   - create
   - update
+  - delete
 - apiGroups:
   - authentication.open-cluster-management.io
   resources:

--- a/charts/managed-serviceaccount/templates/clusterrole.yaml
+++ b/charts/managed-serviceaccount/templates/clusterrole.yaml
@@ -108,6 +108,7 @@ rules:
       - watch
       - create
       - update
+      - delete
   - apiGroups:
       - ""
     resources:

--- a/deploy/bases/hub-clusterrole.yaml
+++ b/deploy/bases/hub-clusterrole.yaml
@@ -13,6 +13,7 @@ rules:
   - watch
   - create
   - update
+  - delete
 - apiGroups:
   - authentication.open-cluster-management.io
   resources:

--- a/pkg/addon/manager/addon.go
+++ b/pkg/addon/manager/addon.go
@@ -130,7 +130,7 @@ func setupPermission(nativeClient kubernetes.Interface) agent.PermissionConfigFu
 			Rules: []rbacv1.PolicyRule{
 				{
 					APIGroups: []string{""},
-					Verbs:     []string{"get", "list", "watch", "create", "update"},
+					Verbs:     []string{"get", "list", "watch", "create", "update", "delete"},
 					Resources: []string{"secrets"},
 				},
 				{


### PR DESCRIPTION
## Summary

The `OwnerReferencesPermissionEnforcement` admission plugin requires `delete` permission on the child resource when modifying `ownerReferences` during an Update operation. After backup/restore, the `ManagedServiceAccount` CR gets a new UID, causing the token controller to update the `ownerReference` on the token secret — which fails without `delete` permission.

## Root Cause

`buildSecret()` in `pkg/addon/agent/controller/token.go` unconditionally sets `OwnerReferences` on the token secret pointing to the MSA CR. After a hub backup/restore:

1. The MSA CR is restored with a **new UID** (Velero does not preserve UIDs)
2. The existing token secret has an `ownerReference` with the **old UID**
3. The token controller calls `Update` on the secret with the new UID in the `ownerReference`
4. The Kubernetes admission plugin checks `delete` permission on the secret — and rejects it because the verb was missing

The error seen is:
```
failed to update the token secret: secrets "auto-import-account" is forbidden:
cannot set an ownerRef on a resource you can't delete
```

Note: this is only triggered on **Update** (not Create) when the `ownerReference` field changes. Initial secret creation is unaffected.

## Fix

Add `delete` to the secrets RBAC rules in all deployment paths:

- `setupPermission()` — runtime Role creation for Deployment mode (also required to avoid RBAC escalation prevention when the manager creates the Role)
- `agent-registration-clusterrole.yaml` — static ClusterRole for AddOnTemplate mode
- `clusterrole.yaml` — manager's own ClusterRole (required for escalation prevention in Deployment mode)
- `deploy/bases/hub-clusterrole.yaml` — static manifest, for consistency

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved add-on agent and manager permissions to allow deletion of Kubernetes Secrets.
  * Updated related deployment permissions to keep Secret management consistent across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->