### PR TITLE
:seedling: Fix Ginkgo argument variable name

### DIFF
--- a/.github/workflows/go-presubmit.yml
+++ b/.github/workflows/go-presubmit.yml
@@ -227,11 +227,11 @@ jobs:
             --set targetCluster=loopback
       - name: Run e2e test
         run: |
-          make test-e2e GENKGO_ARGS='--ginkgo.label-filter='\''!ephemeral&&!install'\'''
+          make test-e2e GINKGO_ARGS='--ginkgo.label-filter='\''!ephemeral&&!install'\'''
           # run ephemeral tests after non-ephemeral and non-install tests to wait for the addon agent to be steady
-          make test-e2e GENKGO_ARGS='--ginkgo.label-filter=ephemeral'
+          make test-e2e GINKGO_ARGS='--ginkgo.label-filter=ephemeral'
           # run install tests after non-ephemeral tests since it may cause the addon agent to be restarted
-          make test-e2e GENKGO_ARGS='--ginkgo.label-filter='\''install&&!deployment-install'\'''
+          make test-e2e GINKGO_ARGS='--ginkgo.label-filter='\''install&&!deployment-install'\'''
       - name: Dump e2e diagnostics
         if: failure()
         run: |

--- a/Makefile
+++ b/Makefile
@@ -177,7 +177,7 @@ test-integration:
 	@echo "TODO: Run integration test"
 
 test-e2e: build-e2e
-	./bin/e2e --test-cluster $(E2E_TEST_CLUSTER_NAME) $(GENKGO_ARGS)
+	./bin/e2e --test-cluster $(E2E_TEST_CLUSTER_NAME) $(GINKGO_ARGS)
 
 code-gen: client-gen lister-gen informer-gen ## Generate clientset, listers and informers
 	hack/code_gen.sh


### PR DESCRIPTION
## Summary

Fix the misspelled `GENKGO_ARGS` Make variable so GitHub Actions label filters are passed to the Ginkgo e2e binary through the intended `GINKGO_ARGS` name.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed end-to-end test configuration so test arguments are passed correctly.
  * Preserved existing test labels, filters, and execution order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->