### PR TITLE
:seedling: chore: dynamically fetch Go version in workflows

### DIFF
--- a/.github/workflows/go-postsubmit.yml
+++ b/.github/workflows/go-postsubmit.yml
@@ -8,9 +8,6 @@ on:
   workflow_dispatch: {}
 
 env:
-  # Common versions
-  GO_VERSION: '1.26'
-  GO_REQUIRED_MIN_VERSION: ''
   GOPATH: '/home/runner/work/managed-serviceaccount/managed-serviceaccount/go'
 
 defaults:
@@ -33,7 +30,7 @@ jobs:
       - name: install Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go/src/open-cluster-management.io/managed-serviceaccount/go.mod
       - name: install imagebuilder
         run: go install github.com/openshift/imagebuilder/cmd/imagebuilder@v1.2.3
       - name: pull base image
@@ -87,7 +84,7 @@ jobs:
       - name: install Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go/src/open-cluster-management.io/managed-serviceaccount/go.mod
       - name: install imagebuilder
         run: go install github.com/openshift/imagebuilder/cmd/imagebuilder@v1.2.3
       - name: pull base image

--- a/.github/workflows/go-presubmit.yml
+++ b/.github/workflows/go-presubmit.yml
@@ -15,9 +15,6 @@ on:
       - release-*
 
 env:
-  # Common versions
-  GO_VERSION: '1.26'
-  GO_REQUIRED_MIN_VERSION: ''
   HELM_VERSION: 'v3.20.1'
 
 jobs:
@@ -32,7 +29,7 @@ jobs:
       - name: install Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
           cache: false
       - name: build
         run: make build
@@ -59,7 +56,7 @@ jobs:
       - name: install Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
           cache: false
       - name: unit
         run: make test
@@ -118,7 +115,7 @@ jobs:
       - name: install Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
           cache: false
       - name: integration
         run: make test-integration
@@ -134,7 +131,7 @@ jobs:
       - name: install Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
           cache: false
       - name: setup helm
         uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
@@ -190,7 +187,7 @@ jobs:
       - name: install Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
           cache: false
       - name: setup helm
         uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1

--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -5,9 +5,6 @@ on:
     tags:
       - 'v*.*.*'
 env:
-  # Common versions
-  GO_VERSION: '1.26'
-  GO_REQUIRED_MIN_VERSION: ''
   HELM_VERSION: 'v3.20.1'
   GITHUB_REF: ${{ github.ref }}
   CHART_NAME: managed-serviceaccount
@@ -50,7 +47,7 @@ jobs:
       - name: install Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
       - name: install imagebuilder
         run: go install github.com/openshift/imagebuilder/cmd/imagebuilder@v1.2.3
       - name: pull base image
@@ -103,7 +100,7 @@ jobs:
       - name: install Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
       - name: install imagebuilder
         run: go install github.com/openshift/imagebuilder/cmd/imagebuilder@v1.2.3
       - name: pull base image


### PR DESCRIPTION
Currently the GitHub workflows rely on a static value for the Go version. It's more maintainable to specify that Go be fetched from the `go.mod` instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build, test, and release workflows to automatically use the Go version specified by the project.
  * Removed manually maintained Go version settings from CI workflows.
  * Helps keep development, testing, and release processes aligned with the project’s configured Go version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->