### PR TITLE
:bug: fix: add non-root USER directive to Dockerfile.cp-creds

### DIFF
--- a/Dockerfile.cp-creds
+++ b/Dockerfile.cp-creds
@@ -7,3 +7,4 @@ RUN GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-$(go env GOHOSTARCH)} CGO_ENABL
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 COPY --from=builder /go/src/github.com/open-cluster-management.io/managed-serviceaccount/bin/cp-creds /
+USER 65532:65532


### PR DESCRIPTION
## Summary

- Commit a051164 ("Harden pod security contexts (#316)") added `USER 65532:65532` to `Dockerfile` but missed `Dockerfile.cp-creds`
- Without the `USER` directive, the cp-creds image defaults to UID 0 (root), which conflicts with `runAsNonRoot: true` pod security settings on non-OpenShift clusters that lack an SCC mutating webhook
- This one-line fix aligns `Dockerfile.cp-creds` with `Dockerfile` by setting the container to run as non-root user 65532

## Test plan

- [x] Verified `Dockerfile.cp-creds` now includes `USER 65532:65532` matching `Dockerfile`
- [ ] Build cp-creds image and verify it runs as UID 65532
- [ ] Confirm no regression on OpenShift (SCC overrides UID from namespace range)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security & Compliance**
  * The `cp-creds` container now runs with a non-root user and group for improved runtime security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->