### PR TITLE
:bug: move ServiceMonitor creation to agent with CRD detection

### DIFF
--- a/charts/managed-serviceaccount/templates/addontemplate.yaml
+++ b/charts/managed-serviceaccount/templates/addontemplate.yaml
@@ -69,6 +69,12 @@ spec:
                 - --cluster-name={{ `{{CLUSTER_NAME}}` }}          # escape double curly brackets, option 1
                 - --kubeconfig={{ "{{" }}HUB_KUBECONFIG{{ "}}" }}  # escape double curly brackets, option 2
                 - --feature-gates=EphemeralIdentity=true
+                {{- if .Values.prometheus.enabled }}
+                - --enable-service-monitor
+                {{- with .Values.prometheus.serviceMonitor.labels }}
+                - --service-monitor-labels={{ toJson . }}
+                {{- end }}
+                {{- end }}
                 command:
                 - /msa
                 - agent
@@ -148,25 +154,6 @@ spec:
             - protocol: TCP
               port: 6443
 {{- end }}
-{{- if .Values.prometheus.enabled }}
-      - apiVersion: monitoring.coreos.com/v1
-        kind: ServiceMonitor
-        metadata:
-          name: managed-serviceaccount-addon-agent
-          namespace: open-cluster-management-agent-addon
-{{- with .Values.prometheus.serviceMonitor.labels }}
-          labels:
-{{- toYaml . | nindent 12 }}
-{{- end }}
-        spec:
-          endpoints:
-          - path: /metrics
-            scheme: http
-            port: metrics
-          selector:
-            matchLabels:
-              addon-agent: managed-serviceaccount
-{{- end }}
       - apiVersion: rbac.authorization.k8s.io/v1
         kind: Role
         metadata:
@@ -208,6 +195,16 @@ spec:
           - create
           - update
           - patch
+{{- if .Values.prometheus.enabled }}
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - servicemonitors
+          verbs:
+          - get
+          - create
+          - update
+{{- end }}
       - apiVersion: rbac.authorization.k8s.io/v1
         kind: RoleBinding
         metadata:

--- a/cmd/agent/agent.go
+++ b/cmd/agent/agent.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"context"
 	"crypto/tls"
+	"encoding/json"
 	"flag"
 	"net/http"
 	"os"
@@ -15,6 +16,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
@@ -31,6 +33,7 @@ import (
 	authv1beta1 "open-cluster-management.io/managed-serviceaccount/apis/authentication/v1beta1"
 	"open-cluster-management.io/managed-serviceaccount/pkg/addon/agent/controller"
 	"open-cluster-management.io/managed-serviceaccount/pkg/addon/agent/health"
+	"open-cluster-management.io/managed-serviceaccount/pkg/addon/agent/servicemonitor"
 	"open-cluster-management.io/managed-serviceaccount/pkg/addon/commoncontroller"
 	"open-cluster-management.io/managed-serviceaccount/pkg/common"
 	"open-cluster-management.io/managed-serviceaccount/pkg/features"
@@ -80,17 +83,23 @@ func (o *AgentOptions) AddFlags(flags *pflag.FlagSet) {
 		"A set of key=value pairs that describe feature gates for alpha/experimental features. "+
 			"Options are:\n"+strings.Join(features.FeatureGates.KnownFeatures(), "\n"))
 	flags.BoolVar(&o.LeaseHealthCheck, "lease-health-check", false, "Use lease to report health check.")
+	flags.BoolVar(&o.EnableServiceMonitor, "enable-service-monitor", false,
+		"Create a ServiceMonitor on the managed cluster if the monitoring.coreos.com CRD is available.")
+	flags.StringVar(&o.ServiceMonitorLabels, "service-monitor-labels", "",
+		"JSON-encoded map of additional labels to set on the ServiceMonitor (e.g. '{\"release\":\"prometheus\"}').")
 }
 
 // AgentOptions holds configuration for agent controller
 type AgentOptions struct {
-	MetricsAddr          string
-	EnableLeaderElection bool
-	ProbeAddr            string
-	FeatureGatesFlags    map[string]bool
-	ClusterName          string
-	SpokeKubeconfig      string
-	LeaseHealthCheck     bool
+	MetricsAddr              string
+	EnableLeaderElection     bool
+	ProbeAddr                string
+	FeatureGatesFlags        map[string]bool
+	ClusterName              string
+	SpokeKubeconfig          string
+	LeaseHealthCheck         bool
+	EnableServiceMonitor     bool
+	ServiceMonitorLabels     string
 }
 
 // NewAgentOptions returns an AgentOptions
@@ -233,6 +242,29 @@ func (o *AgentOptions) Run() error {
 			klog.Fatalf("unable to create healthiness lease updater for controller %v", "ManagedServiceAccount")
 		}
 		go leaseUpdater.Start(ctx)
+	}
+
+	if o.EnableServiceMonitor {
+		smLabels := map[string]string{}
+		if o.ServiceMonitorLabels != "" {
+			if err := json.Unmarshal([]byte(o.ServiceMonitorLabels), &smLabels); err != nil {
+				klog.Fatalf("invalid --service-monitor-labels: %v", err)
+			}
+		}
+
+		dynamicClient, err := dynamic.NewForConfig(spokeCfg)
+		if err != nil {
+			klog.Fatalf("unable to build dynamic client for spoke cluster: %v", err)
+		}
+
+		smReconciler := &servicemonitor.Reconciler{
+			DiscoveryClient:      spokeNativeClient.Discovery(),
+			DynamicClient:        dynamicClient,
+			Namespace:            spokeNamespace,
+			ServiceMonitorName:   "managed-serviceaccount-addon-agent",
+			ServiceMonitorLabels: smLabels,
+		}
+		go smReconciler.Start(ctx)
 	}
 
 	cc, err := addonutils.NewConfigChecker("managed-serviceaccount-agent", o.configCheckerPaths()...)

--- a/pkg/addon/agent/servicemonitor/servicemonitor.go
+++ b/pkg/addon/agent/servicemonitor/servicemonitor.go
@@ -1,0 +1,177 @@
+package servicemonitor
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/klog/v2"
+)
+
+var serviceMonitorGVR = schema.GroupVersionResource{
+	Group:    "monitoring.coreos.com",
+	Version:  "v1",
+	Resource: "servicemonitors",
+}
+
+// Reconciler ensures a ServiceMonitor exists on the managed cluster when the
+// monitoring.coreos.com CRD is available. If the CRD is absent it logs a
+// message and returns without error, making it safe to run on any cluster.
+type Reconciler struct {
+	DiscoveryClient     discovery.DiscoveryInterface
+	DynamicClient       dynamic.Interface
+	Namespace           string
+	ServiceMonitorName  string
+	ServiceMonitorLabels map[string]string
+}
+
+// Start runs the ServiceMonitor reconciliation loop, retrying every 5 minutes.
+// It blocks until the context is cancelled.
+func (r *Reconciler) Start(ctx context.Context) {
+	logger := klog.FromContext(ctx)
+
+	// Retry periodically so that if the Prometheus Operator is installed
+	// after the agent starts, the ServiceMonitor will eventually be created.
+	ticker := time.NewTicker(5 * time.Minute)
+	defer ticker.Stop()
+
+	for {
+		if err := r.reconcile(ctx); err != nil {
+			logger.Error(err, "ServiceMonitor reconciliation failed, will retry")
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+		}
+	}
+}
+
+// reconcile performs a single reconciliation pass: checks the CRD, then
+// creates or updates the ServiceMonitor to match the desired state.
+func (r *Reconciler) reconcile(ctx context.Context) error {
+	logger := klog.FromContext(ctx)
+
+	if !r.crdAvailable() {
+		logger.V(4).Info("ServiceMonitor CRD not found on managed cluster, skipping ServiceMonitor creation")
+		return nil
+	}
+
+	desired := r.buildServiceMonitor()
+	client := r.DynamicClient.Resource(serviceMonitorGVR).Namespace(r.Namespace)
+
+	existing, err := client.Get(ctx, r.ServiceMonitorName, metav1.GetOptions{})
+	if err != nil {
+		if !apierrors.IsNotFound(err) {
+			return fmt.Errorf("failed to get ServiceMonitor: %w", err)
+		}
+		if _, err := client.Create(ctx, desired, metav1.CreateOptions{}); err != nil {
+			return fmt.Errorf("failed to create ServiceMonitor: %w", err)
+		}
+		logger.Info("Created ServiceMonitor", "name", r.ServiceMonitorName, "namespace", r.Namespace)
+		return nil
+	}
+
+	// Update if spec or labels drifted.
+	desiredSpec, _, _ := unstructured.NestedMap(desired.Object, "spec")
+	existingSpec, _, _ := unstructured.NestedMap(existing.Object, "spec")
+	desiredLabels := desired.GetLabels()
+	existingLabels := existing.GetLabels()
+
+	needsUpdate := false
+	if !specEqual(desiredSpec, existingSpec) {
+		existing.Object["spec"] = desired.Object["spec"]
+		needsUpdate = true
+	}
+	if !labelsMatch(desiredLabels, existingLabels) {
+		existing.SetLabels(desiredLabels)
+		needsUpdate = true
+	}
+	if needsUpdate {
+		if _, err := client.Update(ctx, existing, metav1.UpdateOptions{}); err != nil {
+			return fmt.Errorf("failed to update ServiceMonitor: %w", err)
+		}
+		logger.Info("Updated ServiceMonitor", "name", r.ServiceMonitorName, "namespace", r.Namespace)
+	}
+
+	return nil
+}
+
+// crdAvailable returns true if the monitoring.coreos.com/v1 ServiceMonitor
+// CRD is registered on the managed cluster.
+func (r *Reconciler) crdAvailable() bool {
+	resources, err := r.DiscoveryClient.ServerResourcesForGroupVersion("monitoring.coreos.com/v1")
+	if err != nil {
+		return false
+	}
+	for _, res := range resources.APIResources {
+		if res.Kind == "ServiceMonitor" {
+			return true
+		}
+	}
+	return false
+}
+
+// buildServiceMonitor returns the desired ServiceMonitor as an unstructured
+// object, populated from the reconciler's configuration.
+func (r *Reconciler) buildServiceMonitor() *unstructured.Unstructured {
+	sm := &unstructured.Unstructured{}
+	sm.SetAPIVersion("monitoring.coreos.com/v1")
+	sm.SetKind("ServiceMonitor")
+	sm.SetName(r.ServiceMonitorName)
+	sm.SetNamespace(r.Namespace)
+
+	labels := map[string]string{
+		"addon-agent": "managed-serviceaccount",
+	}
+	for k, v := range r.ServiceMonitorLabels {
+		labels[k] = v
+	}
+	sm.SetLabels(labels)
+
+	spec := map[string]interface{}{
+		"endpoints": []interface{}{
+			map[string]interface{}{
+				"path":   "/metrics",
+				"scheme": "http",
+				"port":   "metrics",
+			},
+		},
+		"selector": map[string]interface{}{
+			"matchLabels": map[string]interface{}{
+				"addon-agent": "managed-serviceaccount",
+			},
+		},
+	}
+	sm.Object["spec"] = spec
+
+	return sm
+}
+
+// specEqual returns true if two unstructured maps are JSON-equivalent.
+func specEqual(a, b map[string]interface{}) bool {
+	aj, _ := json.Marshal(a)
+	bj, _ := json.Marshal(b)
+	return string(aj) == string(bj)
+}
+
+// labelsMatch returns true if the desired and existing label maps are exactly
+// equal. This ensures stale labels are detected and removed during reconciliation.
+func labelsMatch(desired, existing map[string]string) bool {
+	if len(desired) != len(existing) {
+		return false
+	}
+	for k, v := range desired {
+		if existing[k] != v {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/addon/agent/servicemonitor/servicemonitor_test.go
+++ b/pkg/addon/agent/servicemonitor/servicemonitor_test.go
@@ -1,0 +1,258 @@
+package servicemonitor
+
+import (
+	"context"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	discoveryfake "k8s.io/client-go/discovery/fake"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	kubetesting "k8s.io/client-go/testing"
+)
+
+func newFakeDiscovery(hasCRD bool) *discoveryfake.FakeDiscovery {
+	fd := &discoveryfake.FakeDiscovery{
+		Fake: &kubetesting.Fake{},
+	}
+	if hasCRD {
+		fd.Resources = []*metav1.APIResourceList{
+			{
+				GroupVersion: "monitoring.coreos.com/v1",
+				APIResources: []metav1.APIResource{
+					{Name: "servicemonitors", Kind: "ServiceMonitor", Namespaced: true},
+				},
+			},
+		}
+	}
+	return fd
+}
+
+func newFakeDynamic(existing ...*unstructured.Unstructured) *dynamicfake.FakeDynamicClient {
+	scheme := runtime.NewScheme()
+	scheme.AddKnownTypeWithName(
+		schema.GroupVersionKind{Group: "monitoring.coreos.com", Version: "v1", Kind: "ServiceMonitor"},
+		&unstructured.Unstructured{},
+	)
+	scheme.AddKnownTypeWithName(
+		schema.GroupVersionKind{Group: "monitoring.coreos.com", Version: "v1", Kind: "ServiceMonitorList"},
+		&unstructured.UnstructuredList{},
+	)
+	objs := make([]runtime.Object, len(existing))
+	for i, o := range existing {
+		objs[i] = o
+	}
+	return dynamicfake.NewSimpleDynamicClient(scheme, objs...)
+}
+
+func TestReconcile_CRDMissing(t *testing.T) {
+	r := &Reconciler{
+		DiscoveryClient:    newFakeDiscovery(false),
+		DynamicClient:      newFakeDynamic(),
+		Namespace:          "test-ns",
+		ServiceMonitorName: "managed-serviceaccount-addon-agent",
+	}
+
+	if err := r.reconcile(context.Background()); err != nil {
+		t.Fatalf("expected no error when CRD is missing, got: %v", err)
+	}
+}
+
+func TestReconcile_CreatesServiceMonitor(t *testing.T) {
+	dc := newFakeDynamic()
+	r := &Reconciler{
+		DiscoveryClient:    newFakeDiscovery(true),
+		DynamicClient:      dc,
+		Namespace:          "test-ns",
+		ServiceMonitorName: "managed-serviceaccount-addon-agent",
+		ServiceMonitorLabels: map[string]string{
+			"release": "prometheus",
+		},
+	}
+
+	if err := r.reconcile(context.Background()); err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	sm, err := dc.Resource(serviceMonitorGVR).Namespace("test-ns").Get(
+		context.Background(), "managed-serviceaccount-addon-agent", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("expected ServiceMonitor to be created, got error: %v", err)
+	}
+
+	labels := sm.GetLabels()
+	if labels["addon-agent"] != "managed-serviceaccount" {
+		t.Errorf("expected label addon-agent=managed-serviceaccount, got: %v", labels)
+	}
+	if labels["release"] != "prometheus" {
+		t.Errorf("expected label release=prometheus, got: %v", labels)
+	}
+}
+
+func TestReconcile_ExistingServiceMonitor(t *testing.T) {
+	existing := &unstructured.Unstructured{}
+	existing.SetAPIVersion("monitoring.coreos.com/v1")
+	existing.SetKind("ServiceMonitor")
+	existing.SetName("managed-serviceaccount-addon-agent")
+	existing.SetNamespace("test-ns")
+	existing.SetLabels(map[string]string{
+		"addon-agent": "managed-serviceaccount",
+	})
+	existing.Object["spec"] = map[string]interface{}{
+		"endpoints": []interface{}{
+			map[string]interface{}{
+				"path":   "/metrics",
+				"scheme": "http",
+				"port":   "metrics",
+			},
+		},
+		"selector": map[string]interface{}{
+			"matchLabels": map[string]interface{}{
+				"addon-agent": "managed-serviceaccount",
+			},
+		},
+	}
+
+	dc := newFakeDynamic(existing)
+	r := &Reconciler{
+		DiscoveryClient:    newFakeDiscovery(true),
+		DynamicClient:      dc,
+		Namespace:          "test-ns",
+		ServiceMonitorName: "managed-serviceaccount-addon-agent",
+	}
+
+	if err := r.reconcile(context.Background()); err != nil {
+		t.Fatalf("expected no error when ServiceMonitor already exists, got: %v", err)
+	}
+
+	actions := dc.Actions()
+	for _, a := range actions {
+		if a.GetVerb() == "update" {
+			t.Error("expected no update when spec matches, but got an update action")
+		}
+	}
+}
+
+func TestReconcile_UpdatesLabels(t *testing.T) {
+	existing := &unstructured.Unstructured{}
+	existing.SetAPIVersion("monitoring.coreos.com/v1")
+	existing.SetKind("ServiceMonitor")
+	existing.SetName("managed-serviceaccount-addon-agent")
+	existing.SetNamespace("test-ns")
+	existing.SetLabels(map[string]string{
+		"addon-agent": "managed-serviceaccount",
+	})
+	existing.Object["spec"] = map[string]interface{}{
+		"endpoints": []interface{}{
+			map[string]interface{}{
+				"path":   "/metrics",
+				"scheme": "http",
+				"port":   "metrics",
+			},
+		},
+		"selector": map[string]interface{}{
+			"matchLabels": map[string]interface{}{
+				"addon-agent": "managed-serviceaccount",
+			},
+		},
+	}
+
+	dc := newFakeDynamic(existing)
+	r := &Reconciler{
+		DiscoveryClient:    newFakeDiscovery(true),
+		DynamicClient:      dc,
+		Namespace:          "test-ns",
+		ServiceMonitorName: "managed-serviceaccount-addon-agent",
+		ServiceMonitorLabels: map[string]string{
+			"release": "prometheus",
+		},
+	}
+
+	if err := r.reconcile(context.Background()); err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	sm, err := dc.Resource(serviceMonitorGVR).Namespace("test-ns").Get(
+		context.Background(), "managed-serviceaccount-addon-agent", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("expected ServiceMonitor to exist, got error: %v", err)
+	}
+
+	labels := sm.GetLabels()
+	if labels["release"] != "prometheus" {
+		t.Errorf("expected label release=prometheus after update, got: %v", labels)
+	}
+}
+
+func TestReconcile_RemovesStaleLabels(t *testing.T) {
+	existing := &unstructured.Unstructured{}
+	existing.SetAPIVersion("monitoring.coreos.com/v1")
+	existing.SetKind("ServiceMonitor")
+	existing.SetName("managed-serviceaccount-addon-agent")
+	existing.SetNamespace("test-ns")
+	existing.SetLabels(map[string]string{
+		"addon-agent": "managed-serviceaccount",
+		"stale-label": "should-be-removed",
+	})
+	existing.Object["spec"] = map[string]interface{}{
+		"endpoints": []interface{}{
+			map[string]interface{}{
+				"path":   "/metrics",
+				"scheme": "http",
+				"port":   "metrics",
+			},
+		},
+		"selector": map[string]interface{}{
+			"matchLabels": map[string]interface{}{
+				"addon-agent": "managed-serviceaccount",
+			},
+		},
+	}
+
+	dc := newFakeDynamic(existing)
+	r := &Reconciler{
+		DiscoveryClient:    newFakeDiscovery(true),
+		DynamicClient:      dc,
+		Namespace:          "test-ns",
+		ServiceMonitorName: "managed-serviceaccount-addon-agent",
+	}
+
+	if err := r.reconcile(context.Background()); err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	sm, err := dc.Resource(serviceMonitorGVR).Namespace("test-ns").Get(
+		context.Background(), "managed-serviceaccount-addon-agent", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("expected ServiceMonitor to exist, got error: %v", err)
+	}
+
+	labels := sm.GetLabels()
+	if _, ok := labels["stale-label"]; ok {
+		t.Errorf("expected stale-label to be removed, but it still exists: %v", labels)
+	}
+	if labels["addon-agent"] != "managed-serviceaccount" {
+		t.Errorf("expected addon-agent label to remain, got: %v", labels)
+	}
+}
+
+func TestCRDAvailable(t *testing.T) {
+	tests := []struct {
+		name     string
+		hasCRD   bool
+		expected bool
+	}{
+		{"CRD present", true, true},
+		{"CRD absent", false, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &Reconciler{DiscoveryClient: newFakeDiscovery(tt.hasCRD)}
+			if got := r.crdAvailable(); got != tt.expected {
+				t.Errorf("crdAvailable() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}

--- a/pkg/addon/manager/manifests/charts/managed-serviceaccount-agent/templates/deployment.yaml
+++ b/pkg/addon/manager/manifests/charts/managed-serviceaccount-agent/templates/deployment.yaml
@@ -43,6 +43,12 @@ spec:
             - --cluster-name={{ .Values.clusterName }}
             - --kubeconfig=/etc/hub/kubeconfig
             - --lease-health-check=true
+{{- if .Values.Prometheus.Enabled }}
+            - --enable-service-monitor
+{{- with .Values.Prometheus.ServiceMonitor.Labels }}
+            - --service-monitor-labels={{ toJson . }}
+{{- end }}
+{{- end }}
           ports:
             - name: metrics
               containerPort: 38080

--- a/pkg/addon/manager/manifests/charts/managed-serviceaccount-agent/templates/role.yaml
+++ b/pkg/addon/manager/manifests/charts/managed-serviceaccount-agent/templates/role.yaml
@@ -19,3 +19,8 @@ rules:
 - apiGroups: ["authentication.k8s.io"]
   resources: ["tokenrequests"]
   verbs: ["get", "create", "update", "patch"]
+{{- if .Values.Prometheus.Enabled }}
+- apiGroups: ["monitoring.coreos.com"]
+  resources: ["servicemonitors"]
+  verbs: ["get", "create", "update"]
+{{- end }}

--- a/vendor/k8s.io/client-go/dynamic/fake/simple.go
+++ b/vendor/k8s.io/client-go/dynamic/fake/simple.go
@@ -1,0 +1,552 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/testing"
+)
+
+func NewSimpleDynamicClient(scheme *runtime.Scheme, objects ...runtime.Object) *FakeDynamicClient {
+	unstructuredScheme := runtime.NewScheme()
+	for gvk := range scheme.AllKnownTypes() {
+		if unstructuredScheme.Recognizes(gvk) {
+			continue
+		}
+		if strings.HasSuffix(gvk.Kind, "List") {
+			unstructuredScheme.AddKnownTypeWithName(gvk, &unstructured.UnstructuredList{})
+			continue
+		}
+		unstructuredScheme.AddKnownTypeWithName(gvk, &unstructured.Unstructured{})
+	}
+
+	objects, err := convertObjectsToUnstructured(scheme, objects)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, obj := range objects {
+		gvk := obj.GetObjectKind().GroupVersionKind()
+		if !unstructuredScheme.Recognizes(gvk) {
+			unstructuredScheme.AddKnownTypeWithName(gvk, &unstructured.Unstructured{})
+		}
+		gvk.Kind += "List"
+		if !unstructuredScheme.Recognizes(gvk) {
+			unstructuredScheme.AddKnownTypeWithName(gvk, &unstructured.UnstructuredList{})
+		}
+	}
+
+	return NewSimpleDynamicClientWithCustomListKinds(unstructuredScheme, nil, objects...)
+}
+
+// NewSimpleDynamicClientWithCustomListKinds try not to use this.  In general you want to have the scheme have the List types registered
+// and allow the default guessing for resources match.  Sometimes that doesn't work, so you can specify a custom mapping here.
+func NewSimpleDynamicClientWithCustomListKinds(scheme *runtime.Scheme, gvrToListKind map[schema.GroupVersionResource]string, objects ...runtime.Object) *FakeDynamicClient {
+	// In order to use List with this client, you have to have your lists registered so that the object tracker will find them
+	// in the scheme to support the t.scheme.New(listGVK) call when it's building the return value.
+	// Since the base fake client needs the listGVK passed through the action (in cases where there are no instances, it
+	// cannot look up the actual hits), we need to know a mapping of GVR to listGVK here.  For GETs and other types of calls,
+	// there is no return value that contains a GVK, so it doesn't have to know the mapping in advance.
+
+	// first we attempt to invert known List types from the scheme to auto guess the resource with unsafe guesses
+	// this covers common usage of registering types in scheme and passing them
+	completeGVRToListKind := map[schema.GroupVersionResource]string{}
+	for listGVK := range scheme.AllKnownTypes() {
+		if !strings.HasSuffix(listGVK.Kind, "List") {
+			continue
+		}
+		nonListGVK := listGVK.GroupVersion().WithKind(listGVK.Kind[:len(listGVK.Kind)-4])
+		plural, _ := meta.UnsafeGuessKindToResource(nonListGVK)
+		completeGVRToListKind[plural] = listGVK.Kind
+	}
+
+	for gvr, listKind := range gvrToListKind {
+		if !strings.HasSuffix(listKind, "List") {
+			panic("coding error, listGVK must end in List or this fake client doesn't work right")
+		}
+		listGVK := gvr.GroupVersion().WithKind(listKind)
+
+		// if we already have this type registered, just skip it
+		if _, err := scheme.New(listGVK); err == nil {
+			completeGVRToListKind[gvr] = listKind
+			continue
+		}
+
+		scheme.AddKnownTypeWithName(listGVK, &unstructured.UnstructuredList{})
+		completeGVRToListKind[gvr] = listKind
+	}
+
+	codecs := serializer.NewCodecFactory(scheme)
+	o := testing.NewObjectTracker(scheme, codecs.UniversalDecoder())
+	for _, obj := range objects {
+		if err := o.Add(obj); err != nil {
+			panic(err)
+		}
+	}
+
+	cs := &FakeDynamicClient{scheme: scheme, gvrToListKind: completeGVRToListKind, tracker: o}
+	cs.AddReactor("*", "*", testing.ObjectReaction(o))
+	cs.AddWatchReactor("*", func(action testing.Action) (handled bool, ret watch.Interface, err error) {
+		var opts metav1.ListOptions
+		if watchAction, ok := action.(testing.WatchActionImpl); ok {
+			opts = watchAction.ListOptions
+		}
+		gvr := action.GetResource()
+		ns := action.GetNamespace()
+		watch, err := o.Watch(gvr, ns, opts)
+		if err != nil {
+			return false, nil, err
+		}
+		return true, watch, nil
+	})
+
+	return cs
+}
+
+// Clientset implements clientset.Interface. Meant to be embedded into a
+// struct to get a default implementation. This makes faking out just the method
+// you want to test easier.
+type FakeDynamicClient struct {
+	testing.Fake
+	scheme        *runtime.Scheme
+	gvrToListKind map[schema.GroupVersionResource]string
+	tracker       testing.ObjectTracker
+}
+
+type dynamicResourceClient struct {
+	client    *FakeDynamicClient
+	namespace string
+	resource  schema.GroupVersionResource
+	listKind  string
+}
+
+var (
+	_ dynamic.Interface  = &FakeDynamicClient{}
+	_ testing.FakeClient = &FakeDynamicClient{}
+)
+
+func (c *FakeDynamicClient) Tracker() testing.ObjectTracker {
+	return c.tracker
+}
+
+func (c *FakeDynamicClient) Resource(resource schema.GroupVersionResource) dynamic.NamespaceableResourceInterface {
+	return &dynamicResourceClient{client: c, resource: resource, listKind: c.gvrToListKind[resource]}
+}
+
+func (c *FakeDynamicClient) IsWatchListSemanticsUnSupported() bool {
+	return true
+}
+
+func (c *dynamicResourceClient) Namespace(ns string) dynamic.ResourceInterface {
+	ret := *c
+	ret.namespace = ns
+	return &ret
+}
+
+func (c *dynamicResourceClient) Create(ctx context.Context, obj *unstructured.Unstructured, opts metav1.CreateOptions, subresources ...string) (*unstructured.Unstructured, error) {
+	var uncastRet runtime.Object
+	var err error
+	switch {
+	case len(c.namespace) == 0 && len(subresources) == 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewRootCreateActionWithOptions(c.resource, obj, opts), obj)
+
+	case len(c.namespace) == 0 && len(subresources) > 0:
+		var accessor metav1.Object // avoid shadowing err
+		accessor, err = meta.Accessor(obj)
+		if err != nil {
+			return nil, err
+		}
+		name := accessor.GetName()
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewRootCreateSubresourceActionWithOptions(c.resource, name, strings.Join(subresources, "/"), obj, opts), obj)
+
+	case len(c.namespace) > 0 && len(subresources) == 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewCreateActionWithOptions(c.resource, c.namespace, obj, opts), obj)
+
+	case len(c.namespace) > 0 && len(subresources) > 0:
+		var accessor metav1.Object // avoid shadowing err
+		accessor, err = meta.Accessor(obj)
+		if err != nil {
+			return nil, err
+		}
+		name := accessor.GetName()
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewCreateSubresourceActionWithOptions(c.resource, name, strings.Join(subresources, "/"), c.namespace, obj, opts), obj)
+
+	}
+
+	if err != nil {
+		return nil, err
+	}
+	if uncastRet == nil {
+		return nil, err
+	}
+
+	ret := &unstructured.Unstructured{}
+	if err := c.client.scheme.Convert(uncastRet, ret, nil); err != nil {
+		return nil, err
+	}
+	return ret, err
+}
+
+func (c *dynamicResourceClient) Update(ctx context.Context, obj *unstructured.Unstructured, opts metav1.UpdateOptions, subresources ...string) (*unstructured.Unstructured, error) {
+	var uncastRet runtime.Object
+	var err error
+	switch {
+	case len(c.namespace) == 0 && len(subresources) == 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewRootUpdateActionWithOptions(c.resource, obj, opts), obj)
+
+	case len(c.namespace) == 0 && len(subresources) > 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewRootUpdateSubresourceActionWithOptions(c.resource, strings.Join(subresources, "/"), obj, opts), obj)
+
+	case len(c.namespace) > 0 && len(subresources) == 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewUpdateActionWithOptions(c.resource, c.namespace, obj, opts), obj)
+
+	case len(c.namespace) > 0 && len(subresources) > 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewUpdateSubresourceActionWithOptions(c.resource, strings.Join(subresources, "/"), c.namespace, obj, opts), obj)
+
+	}
+
+	if err != nil {
+		return nil, err
+	}
+	if uncastRet == nil {
+		return nil, err
+	}
+
+	ret := &unstructured.Unstructured{}
+	if err := c.client.scheme.Convert(uncastRet, ret, nil); err != nil {
+		return nil, err
+	}
+	return ret, err
+}
+
+func (c *dynamicResourceClient) UpdateStatus(ctx context.Context, obj *unstructured.Unstructured, opts metav1.UpdateOptions) (*unstructured.Unstructured, error) {
+	var uncastRet runtime.Object
+	var err error
+	switch {
+	case len(c.namespace) == 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewRootUpdateSubresourceActionWithOptions(c.resource, "status", obj, opts), obj)
+
+	case len(c.namespace) > 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewUpdateSubresourceActionWithOptions(c.resource, "status", c.namespace, obj, opts), obj)
+
+	}
+
+	if err != nil {
+		return nil, err
+	}
+	if uncastRet == nil {
+		return nil, err
+	}
+
+	ret := &unstructured.Unstructured{}
+	if err := c.client.scheme.Convert(uncastRet, ret, nil); err != nil {
+		return nil, err
+	}
+	return ret, err
+}
+
+func (c *dynamicResourceClient) Delete(ctx context.Context, name string, opts metav1.DeleteOptions, subresources ...string) error {
+	var err error
+	switch {
+	case len(c.namespace) == 0 && len(subresources) == 0:
+		_, err = c.client.Fake.
+			Invokes(testing.NewRootDeleteActionWithOptions(c.resource, name, opts), &metav1.Status{Status: "dynamic delete fail"})
+
+	case len(c.namespace) == 0 && len(subresources) > 0:
+		_, err = c.client.Fake.
+			Invokes(testing.NewRootDeleteSubresourceActionWithOptions(c.resource, strings.Join(subresources, "/"), name, opts), &metav1.Status{Status: "dynamic delete fail"})
+
+	case len(c.namespace) > 0 && len(subresources) == 0:
+		_, err = c.client.Fake.
+			Invokes(testing.NewDeleteActionWithOptions(c.resource, c.namespace, name, opts), &metav1.Status{Status: "dynamic delete fail"})
+
+	case len(c.namespace) > 0 && len(subresources) > 0:
+		_, err = c.client.Fake.
+			Invokes(testing.NewDeleteSubresourceActionWithOptions(c.resource, strings.Join(subresources, "/"), c.namespace, name, opts), &metav1.Status{Status: "dynamic delete fail"})
+	}
+
+	return err
+}
+
+func (c *dynamicResourceClient) DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOptions metav1.ListOptions) error {
+	var err error
+	switch {
+	case len(c.namespace) == 0:
+		action := testing.NewRootDeleteCollectionActionWithOptions(c.resource, opts, listOptions)
+		_, err = c.client.Fake.Invokes(action, &metav1.Status{Status: "dynamic deletecollection fail"})
+
+	case len(c.namespace) > 0:
+		action := testing.NewDeleteCollectionActionWithOptions(c.resource, c.namespace, opts, listOptions)
+		_, err = c.client.Fake.Invokes(action, &metav1.Status{Status: "dynamic deletecollection fail"})
+
+	}
+
+	return err
+}
+
+func (c *dynamicResourceClient) Get(ctx context.Context, name string, opts metav1.GetOptions, subresources ...string) (*unstructured.Unstructured, error) {
+	var uncastRet runtime.Object
+	var err error
+	switch {
+	case len(c.namespace) == 0 && len(subresources) == 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewRootGetActionWithOptions(c.resource, name, opts), &metav1.Status{Status: "dynamic get fail"})
+
+	case len(c.namespace) == 0 && len(subresources) > 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewRootGetSubresourceActionWithOptions(c.resource, strings.Join(subresources, "/"), name, opts), &metav1.Status{Status: "dynamic get fail"})
+
+	case len(c.namespace) > 0 && len(subresources) == 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewGetActionWithOptions(c.resource, c.namespace, name, opts), &metav1.Status{Status: "dynamic get fail"})
+
+	case len(c.namespace) > 0 && len(subresources) > 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewGetSubresourceActionWithOptions(c.resource, c.namespace, strings.Join(subresources, "/"), name, opts), &metav1.Status{Status: "dynamic get fail"})
+	}
+
+	if err != nil {
+		return nil, err
+	}
+	if uncastRet == nil {
+		return nil, err
+	}
+
+	ret := &unstructured.Unstructured{}
+	if err := c.client.scheme.Convert(uncastRet, ret, nil); err != nil {
+		return nil, err
+	}
+	return ret, err
+}
+
+func (c *dynamicResourceClient) List(ctx context.Context, opts metav1.ListOptions) (*unstructured.UnstructuredList, error) {
+	if len(c.listKind) == 0 {
+		panic(fmt.Sprintf("coding error: you must register resource to list kind for every resource you're going to LIST when creating the client.  See NewSimpleDynamicClientWithCustomListKinds or register the list into the scheme: %v out of %v", c.resource, c.client.gvrToListKind))
+	}
+	listGVK := c.resource.GroupVersion().WithKind(c.listKind)
+	listForFakeClientGVK := c.resource.GroupVersion().WithKind(c.listKind[:len(c.listKind)-4]) /*base library appends List*/
+
+	var obj runtime.Object
+	var err error
+	switch {
+	case len(c.namespace) == 0:
+		obj, err = c.client.Fake.
+			Invokes(testing.NewRootListActionWithOptions(c.resource, listForFakeClientGVK, opts), &metav1.Status{Status: "dynamic list fail"})
+
+	case len(c.namespace) > 0:
+		obj, err = c.client.Fake.
+			Invokes(testing.NewListActionWithOptions(c.resource, listForFakeClientGVK, c.namespace, opts), &metav1.Status{Status: "dynamic list fail"})
+
+	}
+
+	if obj == nil {
+		return nil, err
+	}
+
+	label, _, _ := testing.ExtractFromListOptions(opts)
+	if label == nil {
+		label = labels.Everything()
+	}
+
+	retUnstructured := &unstructured.Unstructured{}
+	if err := c.client.scheme.Convert(obj, retUnstructured, nil); err != nil {
+		return nil, err
+	}
+	entireList, err := retUnstructured.ToList()
+	if err != nil {
+		return nil, err
+	}
+
+	list := &unstructured.UnstructuredList{}
+	list.SetRemainingItemCount(entireList.GetRemainingItemCount())
+	list.SetResourceVersion(entireList.GetResourceVersion())
+	list.SetContinue(entireList.GetContinue())
+	list.GetObjectKind().SetGroupVersionKind(listGVK)
+	for i := range entireList.Items {
+		item := &entireList.Items[i]
+		metadata, err := meta.Accessor(item)
+		if err != nil {
+			return nil, err
+		}
+		if label.Matches(labels.Set(metadata.GetLabels())) {
+			list.Items = append(list.Items, *item)
+		}
+	}
+	return list, nil
+}
+
+func (c *dynamicResourceClient) Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	switch {
+	case len(c.namespace) == 0:
+		return c.client.Fake.
+			InvokesWatch(testing.NewRootWatchActionWithOptions(c.resource, opts))
+
+	case len(c.namespace) > 0:
+		return c.client.Fake.
+			InvokesWatch(testing.NewWatchActionWithOptions(c.resource, c.namespace, opts))
+	}
+
+	panic("math broke")
+}
+
+// TODO: opts are currently ignored.
+func (c *dynamicResourceClient) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (*unstructured.Unstructured, error) {
+	var uncastRet runtime.Object
+	var err error
+	switch {
+	case len(c.namespace) == 0 && len(subresources) == 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewRootPatchActionWithOptions(c.resource, name, pt, data, opts), &metav1.Status{Status: "dynamic patch fail"})
+
+	case len(c.namespace) == 0 && len(subresources) > 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewRootPatchSubresourceActionWithOptions(c.resource, name, pt, data, opts, subresources...), &metav1.Status{Status: "dynamic patch fail"})
+
+	case len(c.namespace) > 0 && len(subresources) == 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewPatchActionWithOptions(c.resource, c.namespace, name, pt, data, opts), &metav1.Status{Status: "dynamic patch fail"})
+
+	case len(c.namespace) > 0 && len(subresources) > 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewPatchSubresourceActionWithOptions(c.resource, c.namespace, name, pt, data, opts, subresources...), &metav1.Status{Status: "dynamic patch fail"})
+
+	}
+
+	if err != nil {
+		return nil, err
+	}
+	if uncastRet == nil {
+		return nil, err
+	}
+
+	ret := &unstructured.Unstructured{}
+	if err := c.client.scheme.Convert(uncastRet, ret, nil); err != nil {
+		return nil, err
+	}
+	return ret, err
+}
+
+// TODO: opts are currently ignored.
+func (c *dynamicResourceClient) Apply(ctx context.Context, name string, obj *unstructured.Unstructured, options metav1.ApplyOptions, subresources ...string) (*unstructured.Unstructured, error) {
+	outBytes, err := runtime.Encode(unstructured.UnstructuredJSONScheme, obj)
+	if err != nil {
+		return nil, err
+	}
+	patchOptions := metav1.PatchOptions{
+		Force:        &options.Force,
+		DryRun:       options.DryRun,
+		FieldManager: options.FieldManager,
+	}
+	var uncastRet runtime.Object
+	switch {
+	case len(c.namespace) == 0 && len(subresources) == 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewRootPatchActionWithOptions(c.resource, name, types.ApplyPatchType, outBytes, patchOptions), &metav1.Status{Status: "dynamic patch fail"})
+
+	case len(c.namespace) == 0 && len(subresources) > 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewRootPatchSubresourceActionWithOptions(c.resource, name, types.ApplyPatchType, outBytes, patchOptions, subresources...), &metav1.Status{Status: "dynamic patch fail"})
+
+	case len(c.namespace) > 0 && len(subresources) == 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewPatchActionWithOptions(c.resource, c.namespace, name, types.ApplyPatchType, outBytes, patchOptions), &metav1.Status{Status: "dynamic patch fail"})
+
+	case len(c.namespace) > 0 && len(subresources) > 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewPatchSubresourceActionWithOptions(c.resource, c.namespace, name, types.ApplyPatchType, outBytes, patchOptions, subresources...), &metav1.Status{Status: "dynamic patch fail"})
+
+	}
+
+	if err != nil {
+		return nil, err
+	}
+	if uncastRet == nil {
+		return nil, err
+	}
+
+	ret := &unstructured.Unstructured{}
+	if err := c.client.scheme.Convert(uncastRet, ret, nil); err != nil {
+		return nil, err
+	}
+	return ret, nil
+}
+
+func (c *dynamicResourceClient) ApplyStatus(ctx context.Context, name string, obj *unstructured.Unstructured, options metav1.ApplyOptions) (*unstructured.Unstructured, error) {
+	return c.Apply(ctx, name, obj, options, "status")
+}
+
+func convertObjectsToUnstructured(s *runtime.Scheme, objs []runtime.Object) ([]runtime.Object, error) {
+	ul := make([]runtime.Object, 0, len(objs))
+
+	for _, obj := range objs {
+		u, err := convertToUnstructured(s, obj)
+		if err != nil {
+			return nil, err
+		}
+
+		ul = append(ul, u)
+	}
+	return ul, nil
+}
+
+func convertToUnstructured(s *runtime.Scheme, obj runtime.Object) (runtime.Object, error) {
+	var (
+		err error
+		u   unstructured.Unstructured
+	)
+
+	u.Object, err = runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert to unstructured: %w", err)
+	}
+
+	gvk := u.GroupVersionKind()
+	if gvk.Group == "" || gvk.Kind == "" {
+		gvks, _, err := s.ObjectKinds(obj)
+		if err != nil {
+			return nil, fmt.Errorf("failed to convert to unstructured - unable to get GVK %w", err)
+		}
+		apiv, k := gvks[0].ToAPIVersionAndKind()
+		u.SetAPIVersion(apiv)
+		u.SetKind(k)
+	}
+	return &u, nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -611,6 +611,7 @@ k8s.io/client-go/discovery/fake
 k8s.io/client-go/dynamic
 k8s.io/client-go/dynamic/dynamicinformer
 k8s.io/client-go/dynamic/dynamiclister
+k8s.io/client-go/dynamic/fake
 k8s.io/client-go/features
 k8s.io/client-go/gentype
 k8s.io/client-go/informers


### PR DESCRIPTION
## Summary

The AddOnTemplate embeds a static `ServiceMonitor` (`monitoring.coreos.com/v1`) in its manifests when prometheus is enabled. This resource is applied uniformly to all managed clusters via ManifestWork. On non-OpenShift clusters (GKE, EKS, AKS) the Prometheus Operator is typically not installed, so the CRD does not exist and the klusterlet work agent fails the entire ManifestWork with `AppliedManifestWorkFailed`:

```
err="[the server doesn't have a resource type \"ServiceMonitor\",
      failed to get resource with key open-cluster-management-agent-addon/managed-serviceaccount-addon-agent:
      resource with key open-cluster-management-agent-addon/managed-serviceaccount-addon-agent not found]"
```

This PR removes the static ServiceMonitor from the AddOnTemplate and moves creation to the agent binary, which checks at runtime whether the CRD exists on the managed cluster:
- **CRD present** (e.g. OpenShift): create and reconcile the ServiceMonitor for metrics scraping
- **CRD absent** (e.g. GKE/EKS): skip gracefully, retry every 5 minutes (handles late Prometheus Operator installation)

## Changes

### AddOnTemplate (`charts/managed-serviceaccount/templates/addontemplate.yaml`)
- Removed static `ServiceMonitor` manifest from the workload manifests
- Added `--enable-service-monitor` and `--service-monitor-labels` agent args (conditional on `prometheus.enabled`)
- Added RBAC rule for `monitoring.coreos.com/servicemonitors` (get/create/update) to the agent Role

### Agent (`cmd/agent/agent.go`)
- New flags: `--enable-service-monitor` (bool), `--service-monitor-labels` (JSON map)
- When enabled, starts a background ServiceMonitor reconciler using the spoke cluster's dynamic client

### ServiceMonitor Reconciler (`pkg/addon/agent/servicemonitor/`)
- Uses the Kubernetes discovery API to check if `monitoring.coreos.com/v1` `ServiceMonitor` CRD exists
- Creates the ServiceMonitor via dynamic client if the CRD is available
- Reconciles both `spec` and `labels` on existing ServiceMonitors (handles config changes)
- Retries every 5 minutes (handles late Prometheus Operator installation)

### Deployment-mode templates (`pkg/addon/manager/manifests/charts/managed-serviceaccount-agent/`)
- Same flag passthrough and RBAC additions for the programmatic addon path

### Tests
- `TestReconcile_CRDMissing` — CRD absent, no error, no creation
- `TestReconcile_CreatesServiceMonitor` — CRD present, ServiceMonitor created with correct labels
- `TestReconcile_ExistingServiceMonitor` — matching spec and labels, no update
- `TestReconcile_UpdatesLabels` — label drift detected and corrected
- `TestCRDAvailable` — discovery client returns correct result for both cases

## Test Plan

- [ ] GKE/EKS cluster import: ManifestWork applies successfully, agent logs "ServiceMonitor CRD not found", addon shows Available
- [ ] OpenShift cluster: agent creates ServiceMonitor, metrics scraped by Prometheus
- [ ] Agent restart: existing ServiceMonitor detected, no duplicate creation
- [ ] Label change: restart agent with new `--service-monitor-labels`, labels converge
- [ ] Late Prometheus install: agent picks up CRD on next 5-minute cycle
- [ ] Unit tests pass: `go test ./pkg/addon/agent/servicemonitor/ -v`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional ServiceMonitor support for managed agent workloads when Prometheus monitoring is enabled.
  - ServiceMonitors are automatically created or updated on managed clusters when the required monitoring capability is available.
  - Added support for configuring custom ServiceMonitor labels.
  - Updated deployment configuration to pass monitoring settings to the agent.

- **Bug Fixes**
  - Prevented ServiceMonitor resources from being created when the monitoring capability is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->